### PR TITLE
Unimport Mouse from TB2::History

### DIFF
--- a/lib/Test/Builder2/History.pm
+++ b/lib/Test/Builder2/History.pm
@@ -207,5 +207,6 @@ sub is_passing {
     return (grep { $_->is_fail } @{ $self->results }) ? 0 : 1;
 }
 
+no Test::Builder2::Mouse;
 1;
 


### PR DESCRIPTION
May you forgot to unimport Mouse stuff from T::B2::History?
