### PR TITLE
Test+patch for bug in subtest()

### DIFF
--- a/lib/Test/Builder.pm
+++ b/lib/Test/Builder.pm
@@ -233,6 +233,7 @@ sub subtest {
         my $run_the_subtests = sub {
             $subtests->();
             $self->done_testing unless $self->_plan_handled;
+            $? = 0;     # don't fail if $subtests happened to set $? nonzero
             1;
         };
 

--- a/t/subtest/wstat.t
+++ b/t/subtest/wstat.t
@@ -1,0 +1,20 @@
+#!/usr/bin/perl -w
+
+# Test that setting $? doesn't affect subtest success
+
+use strict;
+use Test::More;
+
+subtest foo => sub {
+    plan tests => 1;
+    $? = 1;
+    pass('bar');
+};
+
+subtest foo2 => sub {
+    plan tests => 1;
+    pass('bar2');
+    $? = 1;
+};
+
+done_testing(2);


### PR DESCRIPTION
Hi, Schwern et al.  `subtest()` fails if its callback happens to set `$?` nonzero.  This branch adds a test for the correct behaviour, and a simple patch which makes the test pass.
