### PR TITLE
Bailout inside subtest

### DIFF
--- a/t/subtest/bail_out.t
+++ b/t/subtest/bail_out.t
@@ -1,0 +1,57 @@
+#!/usr/bin/perl -w
+
+BEGIN {
+    if( $ENV{PERL_CORE} ) {
+        chdir 't';
+        @INC = ('../lib', 'lib');
+    }
+    else {
+        unshift @INC, 't/lib';
+    }
+}
+
+my $Exit_Code;
+BEGIN {
+    *CORE::GLOBAL::exit = sub { $Exit_Code = shift; };
+}
+
+use Test::Builder;
+use Test::More;
+
+my $output;
+my $TB = Test::More->builder;
+$TB->output(\$output);
+
+my $Test = Test::Builder->create;
+$Test->level(0);
+
+$Test->plan(tests => 2);
+
+plan tests => 4;
+
+ok 'foo';
+subtest 'bar' => sub {
+    plan tests => 3;
+    ok 'sub_foo';
+    subtest 'sub_bar' => sub {
+        plan tests => 3;
+        ok 'sub_sub_foo';
+        ok 'sub_sub_bar';
+        BAIL_OUT("ROCKS FALL! EVERYONE DIES!");
+        ok 'sub_sub_baz';
+    };
+    ok 'sub_baz';
+};
+
+$Test->is_eq( $output, <<'OUT' );
+1..4
+ok 1
+    1..3
+    ok 1
+        1..3
+        ok 1
+        ok 2
+Bail out!  ROCKS FALL! EVERYONE DIES!
+OUT
+
+$Test->is_eq( $Exit_Code, 255 );


### PR DESCRIPTION
Bailing out of simple tests, like this:

```
plan tests => 3;
pass 'main 1';
BAIL_OUT('OMGWTF!');
pass 'main 2';
pass 'main 3';
```

produces verbose output like you'd expect:

```
1..3
ok 1 - main 1
Bailout called.  Further testing stopped:  OMGWTF!
Bail out!  OMGWTF!
FAILED--Further testing stopped: OMGWTF!
```

But if you bail out of a subtest, like this:

```
plan tests => 3;
pass 'main 1';
subtest 'main 2' => sub {
    plan tests => 2;
    pass 'subtest 1';
    BAIL_OUT('OMGWTF!');
    pass 'subtest 2';
};
pass 'main 3';
```

you get a bunch of spew:

```
1..3
ok 1 - main 1
    1..2
    ok 1 - subtest 1
    Bail out!  OMGWTF!
    not ok 2 - main 2
    # Child (main 2) exited without calling finalize()

    #   Failed test 'main 2'
    #   at
    #   /home/larryl/Test-More/blib/lib/Test/Builder.pm
    #   line 1225.
Dubious, test returned 255 (wstat 65280, 0xff00)
Failed 2/3 subtests

Test Summary Report
-------------------
t/foo.t (Wstat: 65280 Tests: 1 Failed: 0)
  Non-zero exit status: 255
  Parse errors: Bad plan.  You planned 3 tests but ran 1.
Files=1, Tests=1,  0 wallclock secs ( 0.02 usr  0.01 sys +  0.02 cusr  0.01 csys =  0.06 CPU)
Result: FAIL
Failed 1/1 test programs. 0/1 subtests failed.
```

This fix makes BAIL_OUT behave sensibly when called inside a
subtest (even multiple levels deep):

```
1..3
ok 1 - main 1
    1..2
    ok 1 - subtest 1
Bailout called.  Further testing stopped:  OMGWTF!
Bail out!  OMGWTF!
FAILED--Further testing stopped: OMGWTF!
```
