### PR TITLE
Updated test tutorial

### DIFF
--- a/lib/Test/Tutorial.pod
+++ b/lib/Test/Tutorial.pod
@@ -36,7 +36,7 @@ Here's the most basic test program.
 
     print 1 + 1 == 2 ? "ok 1\n" : "not ok 1\n";
 
-since 1 + 1 is 2, it prints:
+Because 1 + 1 is 2, it prints:
 
     1..1
     ok 1
@@ -44,11 +44,11 @@ since 1 + 1 is 2, it prints:
 What this says is: C<1..1> "I'm going to run one test." [1] C<ok 1>
 "The first test passed".  And that's about all magic there is to
 testing.  Your basic unit of testing is the I<ok>.  For each thing you
-test, an C<ok> is printed.  Simple.  B<Test::Harness> interprets your test
+test, an C<ok> is printed.  Simple.  L<Test::Harness> interprets your test
 results to determine if you succeeded or failed (more on that later).
 
 Writing all these print statements rapidly gets tedious.  Fortunately,
-there's B<Test::Simple>.  It has one function, C<ok()>.
+there's L<Test::Simple>.  It has one function, C<ok()>.
 
     #!/usr/bin/perl
 
@@ -56,7 +56,7 @@ there's B<Test::Simple>.  It has one function, C<ok()>.
 
     ok( 1 + 1 == 2 );
 
-and that does the same thing as the code above.  C<ok()> is the backbone
+That does the same thing as the previous code.  C<ok()> is the backbone
 of Perl testing, and we'll be using it instead of roll-your-own from
 here on.  If C<ok()> gets a true value, the test passes.  False, it
 fails.
@@ -67,7 +67,7 @@ fails.
     ok( 1 + 1 == 2 );
     ok( 2 + 2 == 5 );
 
-from that comes
+From that comes:
 
     1..2
     ok 1
@@ -75,27 +75,30 @@ from that comes
     #     Failed test (test.pl at line 5)
     # Looks like you failed 1 tests of 2.
 
-C<1..2> "I'm going to run two tests."  This number is used to ensure
-your test program ran all the way through and didn't die or skip some
-tests.  C<ok 1> "The first test passed."  C<not ok 2> "The second test
-failed".  Test::Simple helpfully prints out some extra commentary about
-your tests.
+C<1..2> "I'm going to run two tests."  This number is a I<plan>. It helps to
+ensure your test program ran all the way through and didn't die or skip some
+tests.  C<ok 1> "The first test passed."  C<not ok 2> "The second test failed".
+Test::Simple helpfully prints out some extra commentary about your tests.
 
 It's not scary.  Come, hold my hand.  We're going to give an example
 of testing a module.  For our example, we'll be testing a date
-library, B<Date::ICal>.  It's on CPAN, so download a copy and follow
+library, L<Date::ICal>.  It's on CPAN, so download a copy and follow
 along. [2]
 
 
 =head2 Where to start?
 
-This is the hardest part of testing, where do you start?  People often
-get overwhelmed at the apparent enormity of the task of testing a
-whole module.  Best place to start is at the beginning.  Date::ICal is
-an object-oriented module, and that means you start by making an
-object.  So we test C<new()>.
+This is the hardest part of testing, where do you start?  People often get
+overwhelmed at the apparent enormity of the task of testing a whole module.
+The best place to start is at the beginning.  C<Date::ICal> is an
+object-oriented module, and that means you start by making an object.  Test
+C<new()>.
 
     #!/usr/bin/perl
+
+    # assume these two lines are in all subsequent examples
+    use strict;
+    use warnings;
 
     use Test::Simple tests => 2;
 
@@ -105,19 +108,19 @@ object.  So we test C<new()>.
     ok( defined $ical );                # check that we got something
     ok( $ical->isa('Date::ICal') );     # and it's the right class
 
-run that and you should get:
+Run that and you should get:
 
     1..2
     ok 1
     ok 2
 
-congratulations, you've written your first useful test.
+Congratulations! You've written your first useful test.
 
 
 =head2 Names
 
-That output isn't terribly descriptive, is it?  When you have two
-tests you can figure out which one is #2, but what if you have 102?
+That output isn't terribly descriptive, is it?  When you have two tests you can
+figure out which one is #2, but what if you have 102 tests?
 
 Each test can be given a little descriptive name as the second
 argument to C<ok()>.
@@ -127,7 +130,7 @@ argument to C<ok()>.
     ok( defined $ical,              'new() returned something' );
     ok( $ical->isa('Date::ICal'),   "  and it's the right class" );
 
-So now you'd see...
+Now you'll see:
 
     1..2
     ok 1 - new() returned something
@@ -136,19 +139,17 @@ So now you'd see...
 
 =head2 Test the manual
 
-Simplest way to build up a decent testing suite is to just test what
+The simplest way to build up a decent testing suite is to just test what
 the manual says it does. [3] Let's pull something out of the
 L<Date::ICal/SYNOPSIS> and test that all its bits work.
-
-    #!/usr/bin/perl
 
     use Test::Simple tests => 8;
 
     use Date::ICal;
 
     $ical = Date::ICal->new( year => 1964, month => 10, day => 16,
-                             hour => 16, min => 12, sec => 47,
-                             tz => '0530' );
+                             hour => 16,   min   => 12, sec => 47,
+                             tz   => '0530' );
 
     ok( defined $ical,            'new() returned something' );
     ok( $ical->isa('Date::ICal'), "  and it's the right class" );
@@ -159,7 +160,7 @@ L<Date::ICal/SYNOPSIS> and test that all its bits work.
     ok( $ical->month == 10,       '  month()' );
     ok( $ical->year  == 1964,     '  year()'  );
 
-run that and you get:
+Run that and you get:
 
     1..8
     ok 1 - new() returned something
@@ -173,33 +174,30 @@ run that and you get:
     ok 8 -   year()
     # Looks like you failed 1 tests of 8.
 
-Whoops, a failure! [4] Test::Simple helpfully lets us know on what line
-the failure occurred, but not much else.  We were supposed to get 17,
-but we didn't.  What did we get??  Dunno.  We'll have to re-run the
-test in the debugger or throw in some print statements to find out.
+Whoops, a failure! [4] C<Test::Simple> helpfully lets us know on what line the
+failure occurred, but not much else.  We were supposed to get 17, but we
+didn't.  What did we get??  Dunno.  You could re-run the test in the debugger
+or throw in some print statements to find out.
 
-Instead, we'll switch from B<Test::Simple> to B<Test::More>.  B<Test::More>
-does everything B<Test::Simple> does, and more!  In fact, Test::More does
-things I<exactly> the way Test::Simple does.  You can literally swap
-Test::Simple out and put Test::More in its place.  That's just what
+Instead, switch from L<Test::Simple> to L<Test::More>.  C<Test::More>
+does everything C<Test::Simple> does, and more!  In fact, C<Test::More> does
+things I<exactly> the way C<Test::Simple> does.  You can literally swap
+C<Test::Simple> out and put C<Test::More> in its place.  That's just what
 we're going to do.
 
-Test::More does more than Test::Simple.  The most important difference
-at this point is it provides more informative ways to say "ok".
-Although you can write almost any test with a generic C<ok()>, it
-can't tell you what went wrong.  Instead, we'll use the C<is()>
-function, which lets us declare that something is supposed to be the
-same as something else:
-
-    #!/usr/bin/perl
+C<Test::More> does more than C<Test::Simple>.  The most important difference at
+this point is it provides more informative ways to say "ok".  Although you can
+write almost any test with a generic C<ok()>, it can't tell you what went
+wrong.  The C<is()> function lets us declare that something is supposed to be
+the same as something else:
 
     use Test::More tests => 8;
 
     use Date::ICal;
 
     $ical = Date::ICal->new( year => 1964, month => 10, day => 16,
-                             hour => 16, min => 12, sec => 47,
-                             tz => '0530' );
+                             hour => 16,   min   => 12, sec => 47,
+                             tz   => '0530' );
 
     ok( defined $ical,            'new() returned something' );
     ok( $ical->isa('Date::ICal'), "  and it's the right class" );
@@ -211,7 +209,7 @@ same as something else:
     is( $ical->year,    1964,     '  year()'  );
 
 "Is C<$ical-E<gt>sec> 47?"  "Is C<$ical-E<gt>min> 12?"  With C<is()> in place,
-you get some more information
+you get more information:
 
     1..8
     ok 1 - new() returned something
@@ -227,24 +225,24 @@ you get some more information
     ok 8 -   year()
     # Looks like you failed 1 tests of 8.
 
-letting us know that C<$ical-E<gt>day> returned 16, but we expected 17.  A
+Aha. C<$ical-E<gt>day> returned 16, but we expected 17.  A
 quick check shows that the code is working fine, we made a mistake
-when writing up the tests.  Just change it to:
+when writing the tests.  Change it to:
 
     is( $ical->day,     16,       '  day()'   );
 
-and everything works.
+... and everything works.
 
-So any time you're doing a "this equals that" sort of test, use C<is()>.
+Any time you're doing a "this equals that" sort of test, use C<is()>.
 It even works on arrays.  The test is always in scalar context, so you
-can test how many elements are in a list this way. [5]
+can test how many elements are in an array this way. [5]
 
     is( @foo, 5, 'foo has 5 elements' );
 
 
 =head2 Sometimes the tests are wrong
 
-Which brings us to a very important lesson.  Code has bugs.  Tests are
+This brings up a very important lesson.  Code has bugs.  Tests are
 code.  Ergo, tests have bugs.  A failing test could mean a bug in the
 code, but don't discount the possibility that the test is wrong.
 
@@ -279,7 +277,7 @@ or we could set up a little try/expect loop.
     );
 
 
-    while( my($ical_str, $expect) = each %ICal_Dates ) {
+    while( my ($ical_str, $expect) = each %ICal_Dates ) {
         my $ical = Date::ICal->new( ical => $ical_str );
 
         ok( defined $ical,            "new(ical => '$ical_str')" );
@@ -293,12 +291,12 @@ or we could set up a little try/expect loop.
         is( $ical->sec,     $expect->[5],     '  sec()'   );
     }
 
-So now we can test bunches of dates by just adding them to
+Now we can test bunches of dates by just adding them to
 C<%ICal_Dates>.  Now that it's less work to test with more dates, you'll
 be inclined to just throw more in as you think of them.
 Only problem is, every time we add to that we have to keep adjusting
 the C<use Test::More tests =E<gt> ##> line.  That can rapidly get
-annoying.  There's two ways to make this work better.
+annoying.  There are ways to make this work better.
 
 First, we can calculate the plan dynamically using the C<plan()>
 function.
@@ -311,26 +309,32 @@ function.
     );
 
     # For each key in the hash we're running 8 tests.
-    plan tests => keys(%ICal_Dates) * 8;
+    plan tests => keys %ICal_Dates * 8;
 
     ...and then your tests...
 
-Or to be even more flexible, we use C<no_plan>.  This means we're just
+To be even more flexible, use C<done_testing>.  This means we're just
 running some tests, don't know how many. [6]
 
-    use Test::More 'no_plan';   # instead of tests => 32
+    use Test::More;   # instead of tests => 32
 
-now we can just add tests and not have to do all sorts of math to
-figure out how many we're running.
+    ... # tests here
+
+    done_testing();   # reached the end safely
+
+If you don't specify a plan, C<Test::More> expects to see C<done_testing()>
+before your program exits. It will warn you if you forget it. You can give
+C<done_testing()> an optional number of tests you expected to run, and if the
+number ran differs, C<Test::More> will give you another kind of warning.
 
 
 =head2 Informative names
 
-Take a look at this line here
+Take a look at the line:
 
     ok( defined $ical,            "new(ical => '$ical_str')" );
 
-we've added more detail about what we're testing and the ICal string
+We've added more detail about what we're testing and the ICal string
 itself we're trying out to the name.  So you get results like:
 
     ok 25 - new(ical => '19971024T120000')
@@ -342,8 +346,8 @@ itself we're trying out to the name.  So you get results like:
     ok 31 -   min()
     ok 32 -   sec()
 
-if something in there fails, you'll know which one it was and that
-will make tracking down the problem easier.  So try to put a bit of
+If something in there fails, you'll know which one it was and that
+will make tracking down the problem easier.  Try to put a bit of
 debugging information into the test names.
 
 Describe what the tests test, to make debugging a failed test easier
@@ -354,8 +358,6 @@ for you or for the next person who runs your test.
 
 Poking around in the existing Date::ICal tests, I found this in
 F<t/01sanity.t> [7]
-
-    #!/usr/bin/perl
 
     use Test::More tests => 7;
     use Date::ICal;
@@ -377,11 +379,12 @@ F<t/01sanity.t> [7]
 
     is( $t2->epoch, 0,          "  and back to ICal" );
 
-The beginning of the epoch is different on most non-Unix operating
-systems [8].  Even though Perl smooths out the differences for the
-most part, certain ports do it differently.  MacPerl is one off the
-top of my head. [9]  So rather than just putting a comment in the test,
-we can explicitly say it's never going to work and skip the test.
+The beginning of the epoch is different on most non-Unix operating systems [8].
+Even though Perl smooths out the differences for the most part, certain ports
+do it differently.  MacPerl is one off the top of my head. [9]  Rather than
+putting a comment in the test and hoping someone will read the test while
+debugging the failure, we can explicitly say it's never going to work and skip
+the test.
 
     use Test::More tests => 7;
     use Date::ICal;
@@ -391,7 +394,7 @@ we can explicitly say it's never going to work and skip the test.
     is( $t1->epoch, 0,          "Epoch time of 0" );
 
     SKIP: {
-        skip('epoch to ICal not working on MacOS', 6)
+        skip('epoch to ICal not working on Mac OS', 6)
             if $^O eq 'MacOS';
 
         is( $t1->ical, '19700101Z', "  epoch to ical" );
@@ -407,11 +410,11 @@ we can explicitly say it's never going to work and skip the test.
         is( $t2->epoch, 0,          "  and back to ICal" );
     }
 
-A little bit of magic happens here.  When running on anything but
-MacOS, all the tests run normally.  But when on MacOS, C<skip()> causes
-the entire contents of the SKIP block to be jumped over.  It's never
-run.  Instead, it prints special output that tells Test::Harness that
-the tests have been skipped.
+A little bit of magic happens here.  When running on anything but MacOS, all
+the tests run normally.  But when on MacOS, C<skip()> causes the entire
+contents of the SKIP block to be jumped over.  It never runs.  Instead,
+C<skip()> prints special output that tells C<Test::Harness> that the tests have
+been skipped.
 
     1..7
     ok 1 - Epoch time of 0
@@ -422,7 +425,7 @@ the tests have been skipped.
     ok 6 # skip epoch to ICal not working on MacOS
     ok 7 # skip epoch to ICal not working on MacOS
 
-This means your tests won't fail on MacOS.  This means less emails
+This means your tests won't fail on MacOS.  This means fewer emails
 from MacPerl users telling you about failing tests that you know will
 never work.  You've got to be careful with skip tests.  These are for
 tests which don't work and I<never will>.  It is not for skipping
@@ -439,7 +442,7 @@ The tests are wholly and completely skipped. [10]  This will work.
 
 =head2 Todo tests
 
-Thumbing through the Date::ICal man page, I came across this:
+While thumbing through the C<Date::ICal> man page, I came across this:
 
    ical
 
@@ -448,8 +451,8 @@ Thumbing through the Date::ICal man page, I came across this:
    Retrieves, or sets, the date on the object, using any
    valid ICal date/time string.
 
-"Retrieves or sets".  Hmmm, didn't see a test for using C<ical()> to set
-the date in the Date::ICal test suite.  So I'll write one.
+"Retrieves or sets".  Hmmm. I didn't see a test for using C<ical()> to set
+the date in the Date::ICal test suite.  So I wrote one:
 
     use Test::More tests => 1;
     use Date::ICal;
@@ -458,7 +461,7 @@ the date in the Date::ICal test suite.  So I'll write one.
     $ical->ical('20201231Z');
     is( $ical->ical, '20201231Z',   'Setting via ical()' );
 
-run that and I get
+Run that. I saw:
 
     1..1
     not ok 1 - Setting via ical()
@@ -467,10 +470,10 @@ run that and I get
     #     expected: '20201231Z'
     # Looks like you failed 1 tests of 1.
 
-Whoops!  Looks like it's unimplemented.  Let's assume we don't have
-the time to fix this. [11] Normally, you'd just comment out the test
-and put a note in a todo list somewhere.  Instead, we're going to
-explicitly state "this test will fail" by wrapping it in a C<TODO> block.
+Whoops!  Looks like it's unimplemented.  Assume you don't have the time to fix
+this. [11] Normally, you'd just comment out the test and put a note in a todo
+list somewhere.  Instead, explicitly state "this test will fail" by wrapping it
+in a C<TODO> block:
 
     use Test::More tests => 1;
 
@@ -490,14 +493,14 @@ Now when you run, it's a little different:
     #          got: '20010822T201551Z'
     #     expected: '20201231Z'
 
-Test::More doesn't say "Looks like you failed 1 tests of 1".  That '#
-TODO' tells Test::Harness "this is supposed to fail" and it treats a
-failure as a successful test.  So you can write tests even before
+C<Test::More> doesn't say "Looks like you failed 1 tests of 1".  That '#
+TODO' tells C<Test::Harness> "this is supposed to fail" and it treats a
+failure as a successful test.  You can write tests even before
 you've fixed the underlying code.
 
-If a TODO test passes, Test::Harness will report it "UNEXPECTEDLY
-SUCCEEDED".  When that happens, you simply remove the TODO block with
-C<local $TODO> and turn it into a real test.
+If a TODO test passes, C<Test::Harness> will report it "UNEXPECTEDLY
+SUCCEEDED".  When that happens, remove the TODO block with C<local $TODO> and
+turn it into a real test.
 
 
 =head2 Testing with taint mode.
@@ -510,15 +513,14 @@ in mind, it's very important to ensure your module works under taint
 mode.
 
 It's very simple to have your tests run under taint mode.  Just throw
-a C<-T> into the C<#!> line.  Test::Harness will read the switches
+a C<-T> into the C<#!> line.  C<Test::Harness> will read the switches
 in C<#!> and use them to run your tests.
 
-    #!/usr/bin/perl -Tw
+    #!/usr/bin/perl -T
 
     ...test normally here...
 
-So when you say C<make test> it will be run with taint mode and
-warnings on.
+When you say C<make test> it will run with taint mode on.
 
 
 =head1 FOOTNOTES
@@ -538,7 +540,7 @@ some bugs, which is good -- we'll uncover them with our tests.
 =item 3
 
 You can actually take this one step further and test the manual
-itself.  Have a look at B<Test::Inline> (formerly B<Pod::Tests>).
+itself.  Have a look at L<Test::Inline> (formerly L<Pod::Tests>).
 
 =item 4
 
@@ -552,7 +554,7 @@ We'll get to testing the contents of lists later.
 
 But what happens if your test program dies halfway through?!  Since we
 didn't say how many tests we're going to run, how can we know it
-failed?  No problem, Test::More employs some magic to catch that death
+failed?  No problem, C<Test::More> employs some magic to catch that death
 and turn the test into a failure, even if every test passed up to that
 point.
 


### PR DESCRIPTION
Here are a couple of minor cleanups, plus a very quick editorial pass through the tutorial. The biggest change is replacing a discussion of no_plan with done_testing.

This has aged ungracefully, though for a document a decade old it's fared better than I'd feared.
