### PR TITLE
Issue #190 - move counter from TAP to History

### DIFF
--- a/lib/TB2/EventCoordinator.pm
+++ b/lib/TB2/EventCoordinator.pm
@@ -218,6 +218,10 @@ sub post_event {
     my $self  = shift;
     my $event = shift;
 
+    #prevent counter corruption between multiple threads
+    my $history = $self->history;
+    lock $history;
+
     $event = shared_clone($event);
     for my $handler ($self->all_handlers) {
         $handler->accept_event($event, $self);

--- a/lib/Test/Builder.pm
+++ b/lib/Test/Builder.pm
@@ -325,16 +325,8 @@ sub history {
 
 sub counter {
     my $self = shift;
-
-    my $counter = $self->try(sub { $self->formatter->counter; });
-    return $counter if $counter;
-
-    # Fake a counter from the history object.
-    # This will not remember changes to the current_test()
-    $counter = TB2::Counter->new;
-    $counter->set($self->history->results_count);
-
-    return $counter;
+    
+    return $self->history->counter;
 }
 
 =item B<object_id>


### PR DESCRIPTION
Avoid threads corruption

The whole history is locked now to prevent any corruption of
the test state
