### PR TITLE
Issue #220 - Provide Test::Builder::name().

### DIFF
--- a/lib/TB2/History.pm
+++ b/lib/TB2/History.pm
@@ -154,8 +154,7 @@ sub subtest_handler {
     my $event = shift;
 
     my $subhistory = $self->new(
-        subtest_depth   => $event->depth,
-        is_subtest      => 1
+        subtest => $event,
     );
 
     return $subhistory;
@@ -471,6 +470,18 @@ has test_end =>
   does          => 'TB2::Event';
 
 
+=head3 subtest
+
+    my $subtest = $history->subtest;
+
+Returns the current C<subtest> event for this object, if there is one.
+
+=cut
+
+has subtest =>
+  is            => 'rw',
+  does          => 'TB2::Event';
+
 =head3 is_subtest
 
     my $is_subtest = $history->is_subtest;
@@ -479,10 +490,11 @@ Returns whether this $history represents a subtest.
 
 =cut
 
-has is_subtest =>
-  is            => 'ro',
-  default       => 0;
+sub is_subtest {
+    my $self = shift;
 
+    return $self->subtest ? 1 : 0;
+}
 
 =head3 subtest_depth
 
@@ -495,11 +507,11 @@ nested is 2 and so on.
 
 =cut
 
-has subtest_depth =>
-  is            => 'rw',
-  isa           => 'TB2::Positive_Int',
-  default       => 0;
+sub subtest_depth {
+    my $self = shift;
 
+    return $self->subtest ? $self->subtest->depth : 0;
+}    
 
 =head3 subtest_start
 

--- a/lib/Test/Builder.pm
+++ b/lib/Test/Builder.pm
@@ -1811,6 +1811,20 @@ sub summary {
     return map { $_->is_fail ? 0 : 1 } @{$self->history->results};
 }
 
+=item B<name>
+
+    my $name = $Test->name;
+
+Returns the name of the current subtest or test.
+
+=cut
+
+sub name {
+    my $self = shift;
+
+    my $name = $self->in_subtest ? $self->history->subtest->name : $0;
+}
+
 =item B<details>
 
     my @tests = $Test->details;

--- a/t/Builder/name.t
+++ b/t/Builder/name.t
@@ -1,0 +1,35 @@
+#!/usr/bin/perl -w
+
+use strict;
+use warnings;
+
+use lib 't/lib';
+use Test::Builder::NoOutput;
+
+use Test::More;
+
+# Formatting may change if we're running under Test::Harness.
+local $ENV{HARNESS_ACTIVE} = 0;
+
+note "name test"; {
+#line 16
+    my $tb = Test::Builder::NoOutput->create;
+    $tb->level(0);
+
+    is($tb->name, __FILE__, "Test name is correct");
+
+    $tb->subtest( first_subtest => sub {
+        $tb->plan('no_plan');
+        is($tb->name, 'first_subtest', "Subtest name is correct");
+
+        $tb->subtest( second_subtest => sub {
+            is($tb->name, 'second_subtest', "Depth subtest name is correct");
+        });
+
+        is($tb->name, 'first_subtest', "Subtest name is correct back in parent");
+    });
+
+    is($tb->name, __FILE__, "Main test name is still correct");
+}
+
+done_testing;


### PR DESCRIPTION
Update TB2::History to store a reference to the subtest object if it has one
rather than tracking state information about the subtest separately.
