### PR TITLE
subtest should auto-note at the beginning of the test

### DIFF
--- a/lib/Test/Builder.pm
+++ b/lib/Test/Builder.pm
@@ -237,6 +237,9 @@ sub subtest {
         $self->croak("subtest()'s second argument must be a code ref");
     }
 
+    # Add subtest note for clarification of starting point
+    $self->note("Subtest: $name");
+    
     # Turn the child into the parent so anyone who has stored a copy of
     # the Test::Builder singleton will get the child.
     my $error;

--- a/lib/Test/Builder/Tester.pm
+++ b/lib/Test/Builder/Tester.pm
@@ -511,7 +511,7 @@ sub complaint {
     my $self   = shift;
     my $type   = $self->type;
     my $got    = $self->got;
-    my $wanted = join "\n", @{ $self->wanted };
+    my $wanted = join '', @{ $self->wanted };
 
     # are we running in colour mode?
     if(Test::Builder::Tester::color) {

--- a/lib/Test/More.pm
+++ b/lib/Test/More.pm
@@ -706,6 +706,7 @@ This would produce.
 
   1..3
   ok 1 - First test
+  # Subtest: An example subtest
       1..2
       ok 1 - This is a subtest
       ok 2 - So is this

--- a/t/subtest/bail_out.t
+++ b/t/subtest/bail_out.t
@@ -46,8 +46,10 @@ subtest 'bar' => sub {
 $Test->is_eq( $output, <<'OUT' );
 1..4
 ok 1
+# Subtest: bar
     1..3
     ok 1
+    # Subtest: sub_bar
         1..3
         ok 1
         ok 2

--- a/t/subtest/line_numbers.t
+++ b/t/subtest/line_numbers.t
@@ -26,6 +26,7 @@ $ENV{HARNESS_ACTIVE} = 0;
 our %line;
 
 {
+    test_out("# Subtest: namehere");
     test_out("    1..3");
     test_out("    ok 1");
     test_out("    not ok 2");
@@ -46,6 +47,7 @@ our %line;
     test_test("un-named inner tests");
 }
 {
+    test_out("# Subtest: namehere");
     test_out("    1..3");
     test_out("    ok 1 - first is good");
     test_out("    not ok 2 - second is bad");
@@ -76,6 +78,7 @@ sub run_the_subtest {
     }; BEGIN{ $line{outerfail3} = __LINE__ }
 }
 {
+    test_out("# Subtest: namehere");
     test_out("    1..3");
     test_out("    ok 1 - first is good");
     test_out("    not ok 2 - second is bad");
@@ -92,6 +95,7 @@ sub run_the_subtest {
     test_test("subtest() called from a sub");
 }
 {
+    test_out("# Subtest: namehere");
     test_out( "    1..0");
     test_err( "    # No tests run!");
     test_out( 'not ok 1 - No tests run for subtest "namehere"');
@@ -105,6 +109,7 @@ sub run_the_subtest {
     test_test("lineno in 'No tests run' diagnostic");
 }
 {
+    test_out("# Subtest: namehere");
     test_out("    1..1");
     test_out("    not ok 1 - foo is bar");
     test_err("    #   Failed test 'foo is bar'");

--- a/t/subtest/predicate.t
+++ b/t/subtest/predicate.t
@@ -16,7 +16,7 @@ BEGIN {
 use strict;
 use warnings;
 
-use Test::More tests => 4;
+use Test::More tests => 5;
 use Test::Builder;
 use Test::Builder::Tester;
 
@@ -40,6 +40,7 @@ sub foobar_ok ($;$) {
     };
 }
 {
+    test_out("# Subtest: namehere");
     test_out("    1..2");
     test_out("    ok 1 - foo");
     test_out("    not ok 2 - bar");
@@ -64,6 +65,7 @@ sub foobar_ok_2 ($;$) {
     foobar_ok($value, $name);
 }
 {
+    test_out("# Subtest: namehere");
     test_out("    1..2");
     test_out("    ok 1 - foo");
     test_out("    not ok 2 - bar");
@@ -93,6 +95,7 @@ sub barfoo_ok ($;$) {
     });
 }
 {
+    test_out("# Subtest: namehere");
     test_out("    1..2");
     test_out("    ok 1 - foo");
     test_out("    not ok 2 - bar");
@@ -117,6 +120,7 @@ sub barfoo_ok_2 ($;$) {
     barfoo_ok($value, $name);
 }
 {
+    test_out("# Subtest: namehere");
     test_out("    1..2");
     test_out("    ok 1 - foo");
     test_out("    not ok 2 - bar");
@@ -134,8 +138,10 @@ sub barfoo_ok_2 ($;$) {
 
 # A subtest-based predicate called from within a subtest
 {
+    test_out("# Subtest: outergroup");
     test_out("    1..2");
     test_out("    ok 1 - this passes");
+    test_out("    # Subtest: namehere");
     test_out("        1..2");
     test_out("        ok 1 - foo");
     test_out("        not ok 2 - bar");
@@ -145,6 +151,7 @@ sub barfoo_ok_2 ($;$) {
     test_out("    not ok 2 - namehere");
     test_err("    #   Failed test 'namehere'");
     test_err("    #   at $0 line $line{ipredcall}.");
+    test_err("    # Looks like you failed 1 test of 2.");
     test_out("not ok 1 - outergroup");
     test_err("#   Failed test 'outergroup'");
     test_err("#   at $0 line $line{outercall}.");
@@ -154,5 +161,6 @@ sub barfoo_ok_2 ($;$) {
         ok 1, "this passes";
         barfoo_ok_2 "foot", "namehere"; BEGIN{ $line{ipredcall} = __LINE__ }
     }; BEGIN{ $line{outercall} = __LINE__ }
-}
 
+    test_test("outergroup with internal barfoo_ok_2 failing line numbers");
+}

--- a/t/subtest/todo.t
+++ b/t/subtest/todo.t
@@ -52,6 +52,7 @@ sub test_subtest_in_todo {
         my ($set_via, $todo_reason, $level) = @$combo;
 
         test_out(
+            "# Subtest: xxx",
             @outlines,
             "not ok 1 - $xxx # TODO $todo_reason",
             "#   Failed (TODO) test '$xxx'",


### PR DESCRIPTION
Currently, following the path of a subtest within direct mode (non-harness) can be a tad confusing.  For example, take this:

```
ok 2 - MANIFEST
    1..8
    ok 1 - Standard stuff at the beginning
    ok 2 - NAME
    ok 3 - AUTHOR
    ok 4 - VERSION_FROM
    ok 5 - ABSTRACT_FROM
    not ok 6 - LICENSE
    #   Failed test 'LICENSE'
    #   at t\test-dist.t line 661.
    #   blah, blah, blah......
```

At first glance, you think "Hmpf, looks like something within MANIFEST failed.", but you'd be wrong.  The subtest result doesn't give you the super description until AFTER the sub has completed.  The change here will put in an auto-note to give a quick reference of the issue:

```
ok 2 - MANIFEST
# SUBTEST: Build.PL ==>
    1..8
    ok 1 - Standard stuff at the beginning
    ok 2 - NAME
    ok 3 - AUTHOR
    ok 4 - VERSION_FROM
    ok 5 - ABSTRACT_FROM
    not ok 6 - LICENSE
    #   Failed test 'LICENSE'
    #   at t\test-dist.t line 661.
    #   blah, blah, blah......
```

Now you know, without having to scroll past all of the Failed test debug data, that this subtest block is actually referencing Build.PL, not MANIFEST.
