### PR TITLE
Colin/test log

### DIFF
--- a/dist/test_dists
+++ b/dist/test_dists
@@ -3,11 +3,21 @@
 # Test the installed version of Test::More vs whatever's sitting in /tmp/tb2/lib/perl5
 # If we get the same result from both, that's a pass.
 
+# Usage dist/test_dists --mirror file:///var/local/CPAN_mirror --lib=/tmp/tb2/lib/perl5
+
 use perl5i::2;
 use CPAN;
 
 use Test::More;
 use Path::Tiny;
+use Getopt::Long;
+my $mirror = "file:///var/local/CPAN_mirror";
+my $lib_path = "/tmp/tb2/lib/perl5";
+my $nomirror;
+my $result = GetOptions ("nomirror" => \$nomirror,
+                        "mirror=s" => \$mirror,    # numeric
+                        "lib=s"    => \$lib_path);
+
 
 CPAN::HandleConfig->load;
 $CPAN::Config->{test_report} = 0;
@@ -25,6 +35,9 @@ my @failed_dists;
 
 note sprintf "%d dists to test", scalar @dist_list;
 
+my $temp = Path::Tiny->tempdir(UNLINK => 0);
+note "Creating directory $temp for test reports";
+
 for my $dist (@dist_list->shuffle) {
     my($mod_name) = $dist =~ m{([^/]+)$};
     $mod_name =~ s{-[^-]+$}{};
@@ -33,11 +46,9 @@ for my $dist (@dist_list->shuffle) {
     next if $skip_dists{$mod_name};
 
     note $mod_name;
-    my $temp = Path::Tiny->tempdir;
-    note "Creating directory $temp for test reports";
 
     my @results;
-    for my $perl5lib ('', "/tmp/tb2/lib/perl5") {
+    for my $perl5lib ('', $lib_path) {
         local $ENV{PERL5LIB} = $perl5lib;
         note "PERL5LIB=$perl5lib";
 
@@ -45,9 +56,12 @@ for my $dist (@dist_list->shuffle) {
         eval {
             local $SIG{ALRM} = sub { die "Alarm!\n" };
             alarm 60*5;
-            $test_out = `cpanm --mirror file:///var/local/CPAN_mirror --mirror-only --test-only $mod_name 2>&1`;
-            my $mod_file = $mod_name =~ s/::/-/g;
-            my $new_file = $temp->child("$mod_file-build.log");
+            my $mirror_settings = '';
+            $mirror_settings = "--mirror $mirror --mirror-only" unless $nomirror;
+            $test_out = `cpanm $mirror_settings --test-only $mod_name 2>&1`;
+            my $mod_file = $mod_name =~ s/::/-/gr;
+            my $lib_id = $perl5lib =~ s/\//-/gr;
+            my $new_file = $temp->child("$mod_file-$lib_id-build.log");
             path('~/.cpanm/latest-build/build.log')->copy($new_file);
             alarm 0;
         };


### PR DESCRIPTION
This is a quick hack to store the cpanm logs to a /tmp directory.  There is also some basic command line parsing so that you can do,

perl dist/test_dists --nomirror --lib lib/

If you run it with no command line parameters it should use the original options making it relatively backwards compatible, i.e.

perl dist/test_dists --mirror file:///var/local/CPAN_mirror --lib /tmp/tb2/lib/perl5

It adds a dependency on Path::Tiny and Getopt::Long.
