### PR TITLE
s/accessable/accessible/g

### DIFF
--- a/lib/TB2/History.pm
+++ b/lib/TB2/History.pm
@@ -67,7 +67,7 @@ new() takes the following options.
 =head3 store_events
 
 If true, $history will keep a complete record of all test events
-accessable via L<events> and L<results>.  This will cause memory usage
+accessible via L<events> and L<results>.  This will cause memory usage
 to grow over the life of the test.
 
 If false, $history will discard events and only keep a summary of

--- a/lib/Test/Builder.pm
+++ b/lib/Test/Builder.pm
@@ -1899,7 +1899,7 @@ sub _results {
 
     $self->croak(<<ERROR);
 Results are not stored by default (saves memory).  Consider using the
-statistical methods of the TB2::History object instead, accessable
+statistical methods of the TB2::History object instead, accessible
 as Test::Builder->history.
 ERROR
 


### PR DESCRIPTION
Replaces two instances of 'accessable' (typos).
