### PR TITLE
Document literal_pass_count and literal_fail_count statistics in History

### DIFF
--- a/lib/TB2/History.pm
+++ b/lib/TB2/History.pm
@@ -349,6 +349,16 @@ A count of the number of failed tests seen.
 
 That is any result for which C<is_fail> is true.
 
+=head3 literal_pass_count
+
+A count of the number of tests passed without regard to any modifiers applied
+to the test result.
+
+=head3 literal_fail_count
+
+A count of the number of tests failed without regard to any modifiers applied
+to the test result.
+
 =head3 todo_count
 
 A count of the number of TODO tests seen.


### PR DESCRIPTION
POD for TB2::History->literal_pass_count and literal_fail_count. 

These methods were used in patching Test::Differences for TB1.5.
