### PR TITLE
Moved the old school result hash conversion method to the result object and made it publicly accessible

### DIFF
--- a/lib/TB2/Result/Base.pm
+++ b/lib/TB2/Result/Base.pm
@@ -246,6 +246,36 @@ sub types {
     return \%types;
 }
 
+=head2 legacy_hash
+
+Returns the result object converted to a legacy hash.  Please don't
+use this method for anything other than legacy support for existing
+test modules.  You will find the result object should provide a 
+far less ambiguous representation of the test results.
+
+=cut
+
+sub legacy_hash {
+    my $self = shift;
+
+    my $types = $self->types;
+    my $type = $self->type eq 'todo_skip' ? "todo_skip"        :
+               $types->{unknown}            ? "unknown"          :
+               $types->{todo}               ? "todo"             :
+               $types->{skip}               ? "skip"             :
+                                            ""                 ;
+
+    my $actual_ok = $types->{unknown} ? undef : $self->literal_pass;
+
+    return {
+        'ok'       => $self->is_fail ? 0 : 1,
+        actual_ok  => $actual_ok,
+        name       => $self->name || "",
+        type       => $type,
+        reason     => $self->reason || "",
+    };
+}
+
 no TB2::Mouse;
 
 1;

--- a/lib/Test/Builder.pm
+++ b/lib/Test/Builder.pm
@@ -1910,30 +1910,9 @@ sub details {
     my $self = shift;
 
     local $Level = $Level + 1;
-    return map { $self->_result_to_hash($_) } @{$self->_results};
+    return map { $_->legacy_hash } @{$self->_results};
 }
 
-sub _result_to_hash {
-    my $self = shift;
-    my $result = shift;
-
-    my $types = $result->types;
-    my $type = $result->type eq 'todo_skip' ? "todo_skip"        :
-               $types->{unknown}            ? "unknown"          :
-               $types->{todo}               ? "todo"             :
-               $types->{skip}               ? "skip"             :
-                                            ""                 ;
-
-    my $actual_ok = $types->{unknown} ? undef : $result->literal_pass;
-
-    return {
-        'ok'       => $result->is_fail ? 0 : 1,
-        actual_ok  => $actual_ok,
-        name       => $result->name || "",
-        type       => $type,
-        reason     => $result->reason || "",
-    };
-}
 
 =item B<todo>
 

--- a/t/Result/basics.t
+++ b/t/Result/basics.t
@@ -105,6 +105,25 @@ sub tests {
             diag            => [],
         }, 'as_hash';
     }
+
+    note "legacy_hash"; {
+        my $result = $new_ok->([
+            pass            => 1,
+            name            => 'something something something test result',
+            test_number     => 23,
+            file            => 'foo.t',
+            line            => 1,
+            event_type      => 'result',
+        ]);
+
+        is_deeply $result->legacy_hash, {
+            ok => 1,
+            actual_ok => 1,
+            name => 'something something something test result',
+            type => '',
+            reason => '',
+        }, 'legacy_hash';
+    }
 }
 
 done_testing;


### PR DESCRIPTION
This should allow us to support old test modules that want to return old result hashes simply.
