### PR TITLE
Fix Test::Builder::Tester so it works with subtests.

### DIFF
--- a/t/Tester/tbt_08subtest.t
+++ b/t/Tester/tbt_08subtest.t
@@ -1,0 +1,16 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use Test::Builder::Tester tests => 1;
+use Test::More;
+
+subtest 'foo' => sub {
+    plan tests => 1;
+
+    test_out("not ok 1 - foo");
+    test_fail(+1);
+    fail("foo");
+    test_test("fail works");
+};


### PR DESCRIPTION
They already work in TB1.5 and this wasn't hard to fix.

For #350

CC @nnutter
