### PR TITLE
fix bug when test_fail is called via a do statement (for 0.98 series)

### DIFF
--- a/lib/Test/Builder/Tester.pm
+++ b/lib/Test/Builder/Tester.pm
@@ -222,7 +222,7 @@ sub test_fail {
     $line = $line + ( shift() || 0 );    # prevent warnings
 
     # expect that on stderr
-    $err->expect("#     Failed test ($0 at line $line)");
+    $err->expect("#     Failed test ($filename at line $line)");
 }
 
 =item test_diag

--- a/t/Tester/tbt_09do.t
+++ b/t/Tester/tbt_09do.t
@@ -1,0 +1,21 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+use Test::Builder::Tester tests => 3;
+use Test::More;
+use File::Basename qw(dirname);
+use File::Spec qw();
+
+my $file = File::Spec->join(dirname(__FILE__), 'tbt_09do_script.pl');
+my $done = do $file;
+ok(defined($done), 'do succeeded') or do {
+    if ($@) {
+        diag qq(  \$@ is '$@'\n);
+    } elsif ($!) {
+        diag qq(  \$! is '$!'\n);
+    } else {
+        diag qq(  file's last statement returned undef: $file)
+    }
+};

--- a/t/Tester/tbt_09do_script.pl
+++ b/t/Tester/tbt_09do_script.pl
@@ -1,0 +1,13 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+isnt($0, __FILE__, 'code is not executing directly');
+
+test_out("not ok 1 - one");
+test_fail(+1);
+ok(0,"one");
+test_test('test_fail caught fail message inside a do');
+
+1;


### PR DESCRIPTION
Ported bug fix and tests from the 1.5 fix to 0.98.  Tried to follow test name convention this time.

test_fail used $0 as the filename instead of the filename reported by
caller. Under normal execution these would be the same but if the test
is executed by a do block then these would no longer be the same.
