### PR TITLE
like() and unlike() no longer warn about undef.

### DIFF
--- a/Changes
+++ b/Changes
@@ -8,6 +8,10 @@
       subtests easier to read. [github #290] [github #364]
       (Brendan Byrd)
 
+    Feature Changes
+    * like() and unlike() no longer warn about undef. [github #335]
+      (Michael G Schwern)
+
 
 0.98_04  Sun Apr 14 10:54:13 BST 2013
     Distribution Changes

--- a/lib/Test/Builder.pm
+++ b/lib/Test/Builder.pm
@@ -1454,14 +1454,19 @@ sub _regex_ok {
     }
 
     {
-        ## no critic (BuiltinFunctions::ProhibitStringyEval)
-
         my $test;
         my $context = $self->_caller_context;
 
-        local( $@, $!, $SIG{__DIE__} );    # isolate eval
+        {
+            ## no critic (BuiltinFunctions::ProhibitStringyEval)
 
-        $test = eval $context . q{$test = $thing =~ /$usable_regex/ ? 1 : 0};
+            local( $@, $!, $SIG{__DIE__} );    # isolate eval
+
+            # No point in issuing an uninit warning, they'll see it in the diagnostics
+            no warnings 'uninitialized';
+
+            $test = eval $context . q{$test = $thing =~ /$usable_regex/ ? 1 : 0};
+        }
 
         $test = !$test if $cmp eq '!~';
 

--- a/t/undef.t
+++ b/t/undef.t
@@ -52,7 +52,7 @@ Test::More->builder->isnt_num(23, undef,  'isnt_num()');
 
 #line 45
 like( undef, qr/.*/,        'undef is like anything' );
-warnings_like(qr/Use of uninitialized value.* at $Filename line 45\.\n/);
+no_warnings;
 
 eq_array( [undef, undef], [undef, 23] );
 no_warnings;


### PR DESCRIPTION
Not much sense, they can see it in the diagnostics, and the warning
message is a bit confusing.

```
Use of uninitialized value $this in pattern match (m//) at x:\test.t line 6.
```

It reports the right location, but there's no $this from the user's
perspective.

This came in because like used to supress all warnings.  That was
fixed in 8b2f0c6e1fb789b0ea5ed217b5be18705bbe6b8c but it let
uninit warnings slip in.

Did it against master because it will merge nicely into Test-Builder1.5.

For #335.
