### PR TITLE
Test::Builder: Fix "return $a or $b" precedence issue

### DIFF
--- a/lib/Test/Builder.pm
+++ b/lib/Test/Builder.pm
@@ -762,7 +762,7 @@ sub _is_dualvar {
 
     no warnings 'numeric';
     my $numval = $val + 0;
-    return $numval != 0 and $numval ne $val ? 1 : 0;
+    return ($numval != 0 and $numval ne $val ? 1 : 0);
 }
 
 =item B<is_eq>


### PR DESCRIPTION
perl parses "return $a or $b" effectively as "return $a;", which is
not what was intended.

Signed-off-by: Niels Thykier niels@thykier.net
