### PR TITLE
subtest accepts @args, passed to code-block

### DIFF
--- a/lib/Test/Builder.pm
+++ b/lib/Test/Builder.pm
@@ -223,15 +223,18 @@ sub child {
 
 =item B<subtest>
 
-    $builder->subtest($name, \&subtests);
+    $builder->subtest($name, \&subtests, @args);
 
-See documentation of C<subtest> in Test::More.
+See documentation of C<subtest> in Test::More.  
+
+C<subtest> also, and optionally, accepts arguments which will be passed to the
+subtests reference.
 
 =cut
 
 sub subtest {
     my $self = shift;
-    my($name, $subtests) = @_;
+    my($name, $subtests, @args) = @_;
 
     if ('CODE' ne ref $subtests) {
         $self->croak("subtest()'s second argument must be a code ref");
@@ -255,7 +258,7 @@ sub subtest {
         my $run_the_subtests = sub {
             # Add subtest name for clarification of starting point
             $self->note("Subtest: $name");
-            $subtests->();
+            $subtests->(@args);
             $self->done_testing unless $self->_plan_handled;
             1;
         };

--- a/t/subtest/args.t
+++ b/t/subtest/args.t
@@ -3,6 +3,17 @@
 use strict;
 use Test::Builder;
 
+BEGIN {
+    if( $ENV{PERL_CORE} ) {
+        chdir 't';
+        @INC = ( '../lib', 'lib' );
+    }
+    else {
+        unshift @INC, 't/lib';
+    }
+}
+use Test::Builder::NoOutput;
+
 my $tb = Test::Builder->new;
 
 $tb->ok( !eval { $tb->subtest() } );
@@ -10,5 +21,13 @@ $tb->like( $@, qr/^\Qsubtest()'s second argument must be a code ref/ );
 
 $tb->ok( !eval { $tb->subtest("foo") } );
 $tb->like( $@, qr/^\Qsubtest()'s second argument must be a code ref/ );
+
+$tb->subtest('Arg passing', sub {
+    my $foo = shift;
+    my $child = Test::Builder->new;
+    $child->is_eq($foo, 'foo');
+    $child->done_testing;
+    $child->finalize;
+}, 'foo');
 
 $tb->done_testing();


### PR DESCRIPTION
This would seem to be the required fix to #346.  Accepting args allows
you to build testing routines like timbunce's `test_psgi` and my
https://github.com/osfameron/test-dbic-calls/
