### PR TITLE
Improved debugger support.

### DIFF
--- a/lib/Test/Builder.pm
+++ b/lib/Test/Builder.pm
@@ -411,7 +411,7 @@ sub _is_provider_tool {
         $sub_is_p = 1 if $pkg && $sub;
     }
     else {
-        ($pkg, $sub) = ($subname =~ m/^(.+)::([^:]+)$/);
+        ($pkg, $sub) = ($subname =~ m/^(.+)::(.+)$/);
         die "$subname: $pkg, $sub: " . join(", " => @call) . "\n" unless $pkg;
         if ($pkg->can('TB_PROVIDER_META') && $sub && $sub ne '__ANON__') {
             my $ref = $pkg->can($sub);


### PR DESCRIPTION
When performed via the debugger, the row number and the colon were added
behind the anonymity functions, and the regular expression did not operate correctly.

Example:
Test::Builder::Provider::**ANON**[lib/Test/Builder/Provider.pm:39]
