### PR TITLE
Fixed so that the test of fork may operate correctly.

### DIFF
--- a/t/Builder/fork_with_new_stdout.t
+++ b/t/Builder/fork_with_new_stdout.t
@@ -24,8 +24,11 @@ else {
 my $pipe = IO::Pipe->new;
 if ( my $pid = fork ) {
   $pipe->reader;
-  $b->ok((<$pipe> =~ /FROM CHILD: ok 1/), "ok 1 from child");
-  $b->ok((<$pipe> =~ /FROM CHILD: 1\.\.1/), "1..1 from child");
+  my $first = <$pipe>;
+  $b->ok(($first =~ /ok 1/), "ok 1 from child");
+
+  my $second = <$pipe>;
+  $b->ok(( $second=~ /1\.\.1/), "1..1 from child");
   waitpid($pid, 0);
 }
 else {
@@ -34,9 +37,9 @@ else {
   close STDOUT;
   open(STDOUT, ">&$pipe_fd");
   my $b = Test::Builder->new;
-  $b->reset;
-  $b->no_plan;
+  $b->reset(shared_stream => 0, new_stream => 1);
   $b->ok(1);
+  $b->done_testing;
 } 
 
 


### PR DESCRIPTION
The test of fork seems not to operate correctly.

```
$ perl -Ilib t/Builder/fork_with_new_stdout.t 
1..2
You tried to plan twice at t/Builder/fork_with_new_stdout.t line 38.
Use of uninitialized value $pipe in pattern match (m//) at t/Builder/fork_with_new_stdout.t line 27.
ok 1
Use of uninitialized value $pipe in pattern match (m//) at t/Builder/fork_with_new_stdout.t line 28.
ok 2
```

In addition, in this pull-request, although it changed so that 'done_testing' might be used, I regard as another problem that 'no_plan' does not print the plan number to last line.
