### PR TITLE
Changed the version of minimum perl to 5.008001.

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,6 +1,6 @@
 #!/usr/bin/perl -w
 
-use 5.008;
+use 5.008001;
 
 use Config;
 use ExtUtils::MakeMaker;
@@ -24,10 +24,7 @@ CHANGE_WARN
 
         sleep 5;
     }
-    if( $] >= 5.008001 && $Config{useithreads} &&
-        $PACKAGE_VERSION < $LAST_THREAD_CHANGE 
-      ) 
-    {
+    if( $Config{useithreads} && $PACKAGE_VERSION < $LAST_THREAD_CHANGE ) {
         printf <<"THREAD_WARN", $LAST_THREAD_CHANGE;
 
 NOTE: The behavior of Test::More and threads has changed between this
@@ -70,14 +67,12 @@ WriteMakefile(
         %Prereqs
     },
 
-    # Added to the core in 5.7.3 and also 5.6.2.
-    INSTALLDIRS     => $] >= 5.006002 ? 'perl' : 'site',
-
+    INSTALLDIRS        => 'site',
     test        => {
         TESTS           => 't/*.t t/*/*.t',
     },
 
-    ($mm_ver < 6.48 ? () : (MIN_PERL_VERSION => 5.008)),
+    ($mm_ver < 6.48 ? () : (MIN_PERL_VERSION => 5.008001)),
 
     ($mm_ver < 6.46 ? () : (META_MERGE => {
         resources => {

--- a/README
+++ b/README
@@ -15,7 +15,7 @@ make
 make test
 make install
 
-It requires Perl version 5.6.0 or newer and Test::Harness 2.03 or newer.
+It requires Perl version 5.8.1 or newer and Test::Harness 2.03 or newer.
 
 
 * More Info

--- a/lib/Test/Builder.pm
+++ b/lib/Test/Builder.pm
@@ -1,6 +1,6 @@
 package Test::Builder;
 
-use 5.006;
+use 5.008001;
 use strict;
 use warnings;
 

--- a/lib/Test/Builder/Threads.pm
+++ b/lib/Test/Builder/Threads.pm
@@ -6,8 +6,7 @@ use warnings;
 BEGIN {
     use Config;
     # Load threads::shared when threads are turned on.
-    # 5.8.0's threads are so busted we no longer support them.
-    if( $] >= 5.008001 && $Config{useithreads} && $INC{'threads.pm'} ) {
+    if( $Config{useithreads} && $INC{'threads.pm'} ) {
         require threads::shared;
 
         # Hack around YET ANOTHER threads::shared bug.  It would
@@ -47,8 +46,6 @@ BEGIN {
             return $_[0];
         };
     }
-    # 5.8.0's threads::shared is busted when threads are off
-    # and earlier Perls just don't have that module at all.
     else {
         *share = sub { return $_[0] };
         *lock  = sub { 0 };

--- a/lib/Test/Tester/Capture.pm
+++ b/lib/Test/Tester/Capture.pm
@@ -12,7 +12,7 @@ use vars qw( @ISA );
 # Make Test::Tester::Capture thread-safe for ithreads.
 BEGIN {
     use Config;
-    if ($] >= 5.008 && $Config{useithreads}) {
+    if ($Config{useithreads}) {
         require threads::shared;
         threads::shared->import;
     }

--- a/t/exit.t
+++ b/t/exit.t
@@ -24,9 +24,6 @@ my $Orig_Dir = cwd;
 
 my $Perl = File::Spec->rel2abs($^X);
 if( $^O eq 'VMS' ) {
-    # VMS can't use its own $^X in a system call until almost 5.8
-    $Perl = "MCR $^X" if $] < 5.007003;
-
     # Quiet noisy 'SYS$ABORT'
     $Perl .= q{ -"I../lib"} if $ENV{PERL_CORE};
     $Perl .= q{ -"Mvmsish=hushed"};


### PR DESCRIPTION
If a support of perl5.6 is dropped, it is better to use a 5.8.1 or newer perl support.

See The Lancaster Consensus
https://github.com/Perl-Toolchain-Gang/toolchain-site/blob/master/lancaster-consensus.md

This will allow test-more modules to reliably use PerlIO and improved Unicode support.
