### PR TITLE
Removed the indent for BAIL_OUT

### DIFF
--- a/lib/Test/Stream.pm
+++ b/lib/Test/Stream.pm
@@ -220,7 +220,7 @@ sub send {
                         my $indent = $se->indent;
 
                         local($\, $", $,) = (undef, ' ', '');
-                        $msg =~ s/^/$indent/mg;
+                        $msg =~ s/^/$indent/mg unless $e->isa('Test::Stream::Event::Bail');
                         print $io $msg if $io && $msg;
                     }
                 }

--- a/t/subtest/bail_out.t
+++ b/t/subtest/bail_out.t
@@ -56,7 +56,7 @@ ok 1
         1..3
         ok 1
         ok 2
-        Bail out!  ROCKS FALL! EVERYONE DIES!
+Bail out!  ROCKS FALL! EVERYONE DIES!
 OUT
 
 $Test->is_eq( $Exit_Code, 255 );


### PR DESCRIPTION
In the latest stable version, when we call the BAIL_OUT in the subtests, indentation does not.

I think if we call the BAIL_OUT, test because it is immediately stopped, it is better to be displayed
in no indentation is easy to understand is BAIL_OUT regardless of the state of the subtest.

Originally, indentation change, which is reflected in the following commit.
https://github.com/Test-More/test-more/commit/fc94f3215812e7f75bab1be54b9b139465d2b1d3
