### PR TITLE
Remove vmsish pragma from one-liners in exit.t.

### DIFF
--- a/t/Legacy/exit.t
+++ b/t/Legacy/exit.t
@@ -23,12 +23,6 @@ use File::Spec;
 my $Orig_Dir = cwd;
 
 my $Perl = File::Spec->rel2abs($^X);
-if( $^O eq 'VMS' ) {
-    # Quiet noisy 'SYS$ABORT'
-    $Perl .= q{ -"I../lib"} if $ENV{PERL_CORE};
-    $Perl .= q{ -"Mvmsish=hushed"};
-}
-
 
 eval { require POSIX; &POSIX::WEXITSTATUS(0) };
 if( $@ ) {


### PR DESCRIPTION
It was broken by f288d674c37d5, which added double quotes around
the double quotes that were already there.

It also hasn't been working as intended for these tests for some
time as they manipulate the exit code directly in an END block,
and that sneaks by the effects of the pragma when run at compile
time.

This works:

  $ perl  -e "require vmsish; import vmsish 'hushed'; END {$? = 1};"

This doesn't:

  $ perl -Mvmsish=hushed -e "END {$? = 1};"

So we'll just live with the noise from the exit messages.  They
don't seem to cause any trouble for the core test suite.
