### PR TITLE
Test failures on Windows due to unescaped paths in regex patterns

### DIFF
--- a/t/Behavior/MonkeyPatching_diag.t
+++ b/t/Behavior/MonkeyPatching_diag.t
@@ -35,7 +35,7 @@ my $orig = Test::Builder->can('diag');
     mostly_like(
         \@warnings,
         [
-            qr{The new sub is 'MyModernTester::__ANON__' defined in $file around line $line},
+            qr{The new sub is 'MyModernTester::__ANON__' defined in \Q$file\E around line $line},
             undef, #Only 1 warning
         ],
         "Found expected warning, just the one"
@@ -69,7 +69,7 @@ my $orig = Test::Builder->can('diag');
     mostly_like(
         \@warnings,
         [
-            qr{The new sub is 'MyModernTester2::__ANON__' defined in $file around line $line},
+            qr{The new sub is 'MyModernTester2::__ANON__' defined in \Q$file\E around line $line},
             undef, #Only 1 warning
         ],
         "new override, new warning"

--- a/t/Behavior/MonkeyPatching_done_testing.t
+++ b/t/Behavior/MonkeyPatching_done_testing.t
@@ -54,7 +54,7 @@ is($ran, 2, "We ran our override both times");
 mostly_like(
     \@warnings,
     [
-        qr{The new sub is 'main::__ANON__' defined in $file around line $line},
+        qr{The new sub is 'main::__ANON__' defined in \Q$file\E around line $line},
         undef,
     ],
     "Got the warning once"

--- a/t/Behavior/MonkeyPatching_note.t
+++ b/t/Behavior/MonkeyPatching_note.t
@@ -35,7 +35,7 @@ my $orig = Test::Builder->can('note');
     mostly_like(
         \@warnings,
         [
-            qr{The new sub is 'MyModernTester::__ANON__' defined in $file around line $line},
+            qr{The new sub is 'MyModernTester::__ANON__' defined in \Q$file\E around line $line},
             undef, #Only 1 warning
         ],
         "Found expected warning, just the one"
@@ -69,7 +69,7 @@ my $orig = Test::Builder->can('note');
     mostly_like(
         \@warnings,
         [
-            qr{The new sub is 'MyModernTester2::__ANON__' defined in $file around line $line},
+            qr{The new sub is 'MyModernTester2::__ANON__' defined in \Q$file\E around line $line},
             undef, #Only 1 warning
         ],
         "new override, new warning"

--- a/t/Behavior/MonkeyPatching_ok.t
+++ b/t/Behavior/MonkeyPatching_ok.t
@@ -37,7 +37,7 @@ my $orig = Test::Builder->can('ok');
     mostly_like(
         \@warnings,
         [
-            qr{The new sub is 'MyModernTester::__ANON__' defined in $file around line $line},
+            qr{The new sub is 'MyModernTester::__ANON__' defined in \Q$file\E around line $line},
             undef, #Only 1 warning
         ],
         "Found expected warning, just the one"
@@ -73,7 +73,7 @@ my $orig = Test::Builder->can('ok');
     mostly_like(
         \@warnings,
         [
-            qr{The new sub is 'MyModernTester2::__ANON__' defined in $file around line $line},
+            qr{The new sub is 'MyModernTester2::__ANON__' defined in \Q$file\E around line $line},
             undef, #Only 1 warning
         ],
         "new override, new warning"

--- a/t/Behavior/MonkeyPatching_plan.t
+++ b/t/Behavior/MonkeyPatching_plan.t
@@ -78,7 +78,7 @@ is($ran, 4, "We ran our override each time");
 mostly_like(
     \@warnings,
     [
-        qr{The new sub is 'main::__ANON__' defined in $file around line $line},
+        qr{The new sub is 'main::__ANON__' defined in \Q$file\E around line $line},
         undef,
     ],
     "Got the warning once"

--- a/t/Test-Stream-Tester.t
+++ b/t/Test-Stream-Tester.t
@@ -97,7 +97,7 @@ events_are(
         event ok => {
             bool => 0,
             diag => [
-                qr{Failed test 'Lets name this test!'.*at (\./)?$0 line}s,
+                qr{Failed test 'Lets name this test!'.*at (\./)?\Q$0\E line}s,
                 qr{  Event: 'ok' from \Q$0\E line $line1}s,
                 qr{  Check: 'ok' from \Q$0\E line $line2}s,
                 qr{  \$got->\{bool\} = '1'},


### PR DESCRIPTION
Fix: Wrap file paths interpolated into regex patterns in \Q ... \E
