### PR TITLE
fix POD errors

### DIFF
--- a/lib/Test/More.pm
+++ b/lib/Test/More.pm
@@ -1695,8 +1695,6 @@ magic side-effects are kept to a minimum.  WYSIWYG.
 
 =head1 SEE ALSO
 
-=head2
-
 =head2 ALTERNATIVES
 
 L<Test::Simple> if all this confuses you and you just want to write

--- a/lib/Test/Tester.pm
+++ b/lib/Test/Tester.pm
@@ -573,7 +573,7 @@ variable also works (if both are set then the British spelling wins out).
 
 =head1 EXPORTED FUNCTIONS
 
-=head3 ($premature, @results) = run_tests(\&test_sub)
+=head2 ($premature, @results) = run_tests(\&test_sub)
 
 \&test_sub is a reference to a subroutine.
 
@@ -586,7 +586,7 @@ the first test.
 
 @results is an array of test result hashes.
 
-=head3 cmp_result(\%result, \%expect, $name)
+=head2 cmp_result(\%result, \%expect, $name)
 
 \%result is a ref to a test result hash.
 
@@ -596,7 +596,7 @@ cmp_result compares the result with the expected values. If any differences
 are found it outputs diagnostics. You may leave out any field from the
 expected result and cmp_result will not do the comparison of that field.
 
-=head3 cmp_results(\@results, \@expects, $name)
+=head2 cmp_results(\@results, \@expects, $name)
 
 \@results is a ref to an array of test results.
 
@@ -608,7 +608,7 @@ number of elements in \@results and \@expects is the same. Then it goes
 through each result checking it against the expected result as in
 cmp_result() above.
 
-=head3 ($premature, @results) = check_tests(\&test_sub, \@expects, $name)
+=head2 ($premature, @results) = check_tests(\&test_sub, \@expects, $name)
 
 \&test_sub is a reference to a subroutine.
 
@@ -620,7 +620,7 @@ checks if the tests died at any stage.
 It returns the same values as run_tests, so you can further examine the test
 results if you need to.
 
-=head3 ($premature, @results) = check_test(\&test_sub, \%expect, $name)
+=head2 ($premature, @results) = check_test(\&test_sub, \%expect, $name)
 
 \&test_sub is a reference to a subroutine.
 
@@ -634,7 +634,7 @@ make sure this is true.
 It returns the same values as run_tests, so you can further examine the test
 results if you need to.
 
-=head3 show_space()
+=head2 show_space()
 
 Turn on the escaping of characters as described in the SPACES AND TABS
 section.

--- a/t/lib/Test/Builder/NoOutput.pm
+++ b/t/lib/Test/Builder/NoOutput.pm
@@ -26,7 +26,7 @@ Test::Builder::NoOutput - A subclass of Test::Builder which prints nothing
 This is a subclass of Test::Builder which traps all its output.
 It is mostly useful for testing Test::Builder.
 
-=head3 read
+=head2 read
 
     my $all_output = $tb->read;
     my $output     = $tb->read($stream);


### PR DESCRIPTION
podchecker had two types of complaints: an empty =head section and
=head3 immediately following =head1 without a =head2 in between.
