### PR TITLE
t/exit.t quote-protect $Perl in case of spaces

### DIFF
--- a/t/exit.t
+++ b/t/exit.t
@@ -30,8 +30,9 @@ if( $^O eq 'VMS' ) {
     # Quiet noisy 'SYS$ABORT'
     $Perl .= q{ -"I../lib"} if $ENV{PERL_CORE};
     $Perl .= q{ -"Mvmsish=hushed"};
+} else {
+    $Perl = qq("$Perl"); # protect from shell if spaces
 }
-
 
 eval { require POSIX; &POSIX::WEXITSTATUS(0) };
 if( $@ ) {


### PR DESCRIPTION
If Perl is installed in a place-with-space, `t/exit.t` breaks (though not on master, only stable). With this, it does not.
