### PR TITLE
Include new Stream API when calculating depth in Test::Tester

### DIFF
--- a/lib/Test/Tester.pm
+++ b/lib/Test/Tester.pm
@@ -47,7 +47,7 @@ sub find_depth {
     my ($start, $end);
     my $l = 1;
     while (my @call = caller($l++)) {
-        $start = $l if $call[3] =~ m/^Test::Builder::(ok|skip|todo_skip)$/;
+        $start = $l if $call[3] =~ m/^Test::Stream::Context::|Test::Builder::(ok|skip|todo_skip)$/;
         next unless $start;
         next unless $call[3] eq 'Test::Tester::run_tests';
         $end = $l;


### PR DESCRIPTION
This is a possible solution for #533. I'm not sure I fully understand how depth is supposed to be calculated. But I decided to take a stab. :)

Depth was only calculated based on Test::Builder and not the new Stream API. The depth just defaulted to being `$Test::Builder::Level` which is always 1 if using the new API (as far as I can tell).

Tested with _97 and all tests pass. Might need another test to make sure depth is calculated correctly for the new API.