### PR TITLE
Subtests and todos

### DIFF
--- a/lib/Test/Stream/Event/Subtest.pm
+++ b/lib/Test/Stream/Event/Subtest.pm
@@ -43,6 +43,24 @@ sub init {
     push @{$self->[DIAG]} => "  No tests run for subtest."
         unless $self->[EXCEPTION] || $self->[EARLY_RETURN] || $self->[STATE]->[STATE_COUNT];
 
+    # I HAVE NO IDEA WHAT I'M DOING !!!
+    # check if any of the sub-tests is a todo, and if 
+    # so mark the aggregate as being a todo as well
+
+    # [8][4] == list of events. There's probably a less savage way
+    # of getting them
+    for my $event ( @{ $self->[8][4] || [] } ) {
+        # only bother if it's an OK event and it's in a todo state
+        next unless ref $event eq 'Test::Stream::Event::Ok' 
+                    and $event->context->in_todo;
+
+        # force the parent test to be in a TODO state
+        $self->context->[3] ||= 1; # force to be TODO
+
+        # if a child fail, so is the parent
+        $self->set_real_bool( 0 ) if not $event->real_bool ;
+    }
+
     # Have the 'OK' init run
     $self->SUPER::init();
 }

--- a/subtest_checks.pl
+++ b/subtest_checks.pl
@@ -1,0 +1,69 @@
+#!/usr/bin/perl 
+
+use strict;
+use warnings;
+
+use Test::More;
+
+subtest passing => sub {
+    pass;
+};
+
+subtest failing => sub {
+    fail;
+};
+
+subtest 'todo okay' => sub {
+    local $TODO = 'normal todo';
+    fail;
+};
+
+subtest 'todo flagged as passing' => sub {
+    local $TODO = 'normal todo';
+    pass;
+};
+
+subtest 'failing' => sub {
+    fail;
+
+    local $TODO = 'normal todo';
+    pass;
+};
+
+subtest 'todo flagged as passing' => sub {
+    pass;
+
+    local $TODO = 'normal todo';
+    pass;
+};
+
+subtest 'todo ok' => sub {
+    pass;
+
+    local $TODO = 'normal todo';
+    fail;
+};
+
+subtest 'embedded top is okay' => sub {
+    subtest 'level 1' => sub {
+        local $TODO = 'normal todo';
+        fail;
+    };
+};
+
+subtest 'embedded top is flagged' => sub {
+    subtest 'level 1' => sub {
+        local $TODO = 'normal todo';
+        pass;
+    };
+};
+
+subtest 'embedded top is flagged' => sub {
+    local $TODO = 'normal todo';
+    subtest 'level 1' => sub {
+        local $TODO = 'normal todo';
+        pass;
+    };
+};
+
+done_testing;


### PR DESCRIPTION
Fair warning: the patch seems to be working, doesn't break the test suites of Test::More. But I'm not exactly fully aware of what I'm doing...

In all cases, TODOs in subtests don't percolate to the aggregate results. This patch addresses that. What I think is a sane aggregate behavior is in the comments in Test::Stream::Event::Subtest. 