### PR TITLE
Make Context+Event stuff less magic

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -6,6 +6,7 @@ examples/subtest.t
 lib/ok.pm
 lib/Test/Builder.pm
 lib/Test/Builder/Module.pm
+lib/Test/Builder/MonkeyPatching.pm
 lib/Test/Builder/Tester.pm
 lib/Test/Builder/Tester/Color.pm
 lib/Test/CanFork.pm

--- a/lib/Test/Builder/MonkeyPatching.pm
+++ b/lib/Test/Builder/MonkeyPatching.pm
@@ -1,41 +1,26 @@
-package Test::Stream::Event::Note;
+package Test::Builder::MonkeyPatching;
 use strict;
 use warnings;
 
-use Test::Stream::Event(
-    accessors  => [qw/message/],
+use Test::Stream::Exporter qw/exports import/;
+exports qw/monkeypatch_events monkeypatch_subs monkeypatch_all/;
+Test::Stream::Exporter->cleanup;
+
+our %EVENTS = (
+    Ok   => [qw/real_bool name/],
+    Plan => [qw/max directive reason/],
+    Diag => [qw/message/],
+    Note => [qw/message/],
 );
 
-use Test::Stream::Carp qw/confess/;
-
-sub init {
-    $_[0]->SUPER::init();
-    if (defined $_[0]->{+MESSAGE}) {
-        $_[0]->{+MESSAGE} .= "";
-    }
-    else {
-        $_[0]->{+MESSAGE} = 'undef';
-    }
-}
-
-sub to_tap {
-    my $self = shift;
-
-    chomp(my $msg = $self->{+MESSAGE});
-    $msg = "# $msg" unless $msg =~ m/^\n/;
-    $msg =~ s/\n/\n# /g;
-
-    return [OUT_STD, "$msg\n"];
-}
-
-sub extra_details {
-    my $self = shift;
-    return ( message => $self->message || '' );
-}
+sub monkeypatch_events() { qw/ok note diag plan/ }
+sub monkeypatch_subs()   { qw/done_testing/ }
+sub monkeypatch_all()    { (monkeypatch_events(), monkeypatch_subs()) }
 
 1;
 
 __END__
+
 
 =pod
 
@@ -43,39 +28,12 @@ __END__
 
 =head1 NAME
 
-Test::Stream::Event::Note - Note event type
+Test::Builder::MonkeyPatching - Metadata for Test::Builder monkeypatching
+legacy support.
 
 =head1 DESCRIPTION
 
-Notes, typically rendered to STDOUT.
-
-=head1 SYNOPSYS
-
-    use Test::Stream::Context qw/context/;
-    use Test::Stream::Event::Note;
-
-    my $ctx = context();
-    my $event = $ctx->Note($message);
-
-=head1 ACCESSORS
-
-=over 4
-
-=item $note->message
-
-The message for the note.
-
-=back
-
-=head1 SUMMARY FIELDS
-
-=over 4
-
-=item message
-
-The message from the note.
-
-=back
+Internal use only, subject to change.
 
 =head1 SOURCE
 

--- a/lib/Test/Stream.pm
+++ b/lib/Test/Stream.pm
@@ -404,8 +404,11 @@ sub done_testing {
         return;
     }
 
-    # Use _plan to bypass Test::Builder::plan() monkeypatching
-    $ctx->_plan($num || $plan || $ran) unless $state->[STATE_PLAN];
+    unless ($state->[STATE_PLAN]) {
+        # bypass Test::Builder::plan() monkeypatching
+        my $e = $ctx->build_event('Plan', max => $num || $plan || $ran);
+        $ctx->send($e);
+    }
 
     if ($plan && $plan != $ran) {
         $state->[STATE_PASSING] = 0;

--- a/lib/Test/Stream/API.pm
+++ b/lib/Test/Stream/API.pm
@@ -239,26 +239,10 @@ example L<Test::Stream::Event::Ok> can be issued via C<< $context->ok(...) >>.
 
     use Test::Stream::API qw/ context /;
     my $context = context();
-    $context->EVENT_TYPE(...);
+    $context->send_event('EVENT_TYPE', ...);
 
-The arguments to the event method are the values for event accessors in order,
-excluding the C<context>, C<created>, and C<in_subtest> arguments. For instance
-here is how the Ok event is defined:
-
-    package Test::Stream::Event::Ok;
-    use Test::Stream::Event(
-        accessors  => [qw/real_bool name diag .../],
-        ...
-    );
-
-This means that the C<< $context->ok >> method takes up to 5 arguments. The
-first argument is a boolean true/false, the second is the name of the test, and
-the third is an arrayref of diagnostics messages or
-L<Test::Stream::Event::Diag> objects.
-
-    $context->ok($bool, $name, [$diag]);
-
-Here are the main event methods, as well as their standard arguments:
+The 5 primary event types each have a shortcut method on
+L<Test::Stream::Context>:
 
 =over 4
 
@@ -305,7 +289,6 @@ methods do for you.
     );
 
     # Make the event
-            # TODO
     my $ok = Test::Stream::Event::Ok->new(
         # Should reflect where the event was produced, NOT WHERE ERRORS ARE REPORTED
         created => [__PACKAGE__, __FILE__,              __LINE__],

--- a/lib/Test/Stream/Architecture.pod
+++ b/lib/Test/Stream/Architecture.pod
@@ -281,33 +281,18 @@ This decision will need to be made before we go stable.
 =head2 GENERATING EVENTS
 
 All event subclasses should use L<Test::Stream::Event> to set them up as
-proper event objects. They should also add a method to
-L<Test::Stream::Context> to be used as a shortcut for generating that event
-type. That will let you can fire off an event directly from your context
-object using the lowercase name of the event class.
+proper event objects. IT is best to use the C<send_event()> method provided by
+the context object:
 
     my $ctx = context;
-    $ctx->ok(1, "pass");
-    $ctx->ok(0, "fail, ["This test failed, here is some diag ..."]);
-    $ctx->note("I am a teapot");
-
-All events take a context and 2 other arguments as the first 3 arguments of
-their constructor, these shortcut methods handle those first 3 arguments for
-you, making life much easier.
-
-The other arguments are:
-
-=over 4
-
-=item created
-
-an arrayref with caller information for where the event was generated.
-
-=item in_subtest
-
-True if the event belongs in a subtest, false otherwise.
-
-=back
+    $ctx->send_event('Ok', real_bool => 1, name => "pass");
+    $ctx->send_event(
+        'Ok',
+        real_bool => 0,
+        name      => "fail",
+        diag      => ["This test failed, here is some diag ..."],
+    );
+    $ctx->send_event('Note', message => "I am a teapot");
 
 =head1 EVENT OBJECTS
 

--- a/lib/Test/Stream/Event.pm
+++ b/lib/Test/Stream/Event.pm
@@ -23,12 +23,10 @@ sub import {
     my $ctx_meth = delete $args{ctx_method};
     my $accessors = $args{accessors} || [];
 
-    require Test::Stream::Context;
     require Test::Stream;
 
     # %args may override base
     Test::Stream::HashBase->apply_to($caller, base => $class, %args);
-    Test::Stream::Context->register_event($caller, $ctx_meth, $accessors);
     Test::Stream::Exporter::export_to(
         'Test::Stream',
         $caller,
@@ -101,15 +99,9 @@ L<Test::Stream>.
     use warnings;
 
     # This will make our class an event subclass, add the specified accessors,
-    # inject a helper method into the context objects, and add constants for
-    # all our fields, and fields we inherit.
+    # add constants for all our fields, and fields we inherit.
     use Test::Stream::Event(
         accessors  => [qw/foo bar baz/],
-        # if no ctx_method is specified it will create one from the lowercase
-        # of the last part of the package name, and it will allow you to
-        # specify any accessor field in order. Or you can manually specify the
-        # method name, and what fields it accepts.
-        ctx_method => ['my_event' => qw/foo/],
     );
 
     # Chance to initialize some defaults
@@ -157,6 +149,11 @@ L<Test::Stream>.
 
     1;
 
+And to use it:
+
+    my $ctx = context();
+    $ctx->send_event('MyEvent', foo => 1, baz => 2);
+
 =head1 IMPORTING
 
 =head2 ARGUMENTS
@@ -165,12 +162,6 @@ In addition to the arguments listed here, you may pass in any arguments
 accepted by L<Test::Stream::HashBase>.
 
 =over 4
-
-=item ctx_method => $NAME
-
-This specifies the name of the helper meth that will be injected into
-L<Test::Stream::Context> to help generate your events. If this is not specified
-it will use the lowercased last section of your package name.
 
 =item base => $BASE_CLASS
 
@@ -197,14 +188,6 @@ alternative base class, which must itself subclass C<Test::Stream::Event>.
 Events B<CAN NOT> use multiple inheritance in most cases. This is mainly
 because events are arrayrefs and not hashrefs. Each subclass must add fields as
 new indexes after the last index of the parent class.
-
-=head2 CONTEXT HELPER
-
-All events need some initial fields for construction. These fields include a
-context, and some other state from construction time. The context object will
-get helper methods for all events that fill in these fields for you. It is not
-advised to ever construct an event object yourself, you should I<always> use
-the context helper method.
 
 =head1 METHODS
 

--- a/lib/Test/Stream/Event/Diag.pm
+++ b/lib/Test/Stream/Event/Diag.pm
@@ -3,8 +3,7 @@ use strict;
 use warnings;
 
 use Test::Stream::Event(
-    accessors  => [qw/message linked/],
-    ctx_method => ['_diag' => 'message'],
+    accessors => [qw/message linked/],
 );
 
 use Test::Stream::Util qw/try/;

--- a/lib/Test/Stream/Event/Ok.pm
+++ b/lib/Test/Stream/Event/Ok.pm
@@ -7,8 +7,7 @@ use Test::Stream::Util qw/unoverload_str/;
 use Test::Stream::Carp qw/confess/;
 
 use Test::Stream::Event(
-    accessors   => [qw/real_bool name diag bool level/],
-    ctx_method  => [ '_ok' => qw/real_bool name diag/ ],
+    accessors => [qw/real_bool name diag bool level/],
 );
 
 sub skip { $_[0]->{+CONTEXT}->skip }
@@ -226,6 +225,16 @@ Examples are C<ok()>, and C<is()>.
 
     my $ctx = context();
     my $event = $ctx->ok($bool, $name, \@diag);
+
+or:
+
+    my $ctx   = context();
+    my $event = $ctx->send_event(
+        'Ok',
+        real_bool => $bool,
+        name      => $name,
+        diag      => \@diag
+    );
 
 =head1 ACCESSORS
 

--- a/lib/Test/Stream/Event/Plan.pm
+++ b/lib/Test/Stream/Event/Plan.pm
@@ -4,7 +4,6 @@ use warnings;
 
 use Test::Stream::Event(
     accessors  => [qw/max directive reason/],
-    ctx_method => ['_plan' => qw/max directive reason/],
 );
 
 use Test::Stream::Carp qw/confess/;

--- a/lib/Test/Stream/Event/Subtest.pm
+++ b/lib/Test/Stream/Event/Subtest.pm
@@ -9,7 +9,6 @@ use Test::Stream qw/-internal STATE_PASSING STATE_COUNT STATE_FAILED STATE_PLAN/
 use Test::Stream::Event(
     base       => 'Test::Stream::Event::Ok',
     accessors  => [qw/state events exception early_return delayed instant/],
-    ctx_method => [subtest => qw/real_bool name/],
 );
 
 sub init {

--- a/lib/Test/Stream/Subtest.pm
+++ b/lib/Test/Stream/Subtest.pm
@@ -81,7 +81,8 @@ This is almost certainly not what you wanted. Did you fork and forget to exit?
 
     $ctx->bail($st->{early_return}->reason) if $er && $er->isa('Test::Stream::Event::Bail');
 
-    my $e = $ctx->send_subtest(
+    my $e = $ctx->send_event(
+        'Subtest',
         name         => $st->{name},
         state        => $st->{state},
         events       => $st->{events},

--- a/lib/Test/Stream/Tester.pm
+++ b/lib/Test/Stream/Tester.pm
@@ -63,10 +63,6 @@ sub event($$) {
     croak "event() cannot be used outside of a check { ... } block"
         unless $EVENTS;
 
-    my $etypes = Test::Stream::Context->events;
-    croak "'$type' is not a valid event type!"
-        unless $etypes->{$type};
-
     my $props;
 
     croak "event() takes a type, followed by a hashref"

--- a/lib/Test/Stream/Tester/Checks/Event.pm
+++ b/lib/Test/Stream/Tester/Checks/Event.pm
@@ -19,10 +19,6 @@ sub new {
 
     my $type = $self->get('type') || confess "No type specified!";
 
-    my $etypes = Test::Stream::Context->events;
-    confess "'$type' is not a valid event type"
-        unless $etypes->{$type};
-
     return $self;
 }
 

--- a/t/Test-Stream-Event.t
+++ b/t/Test-Stream-Event.t
@@ -25,6 +25,4 @@ isa_ok('My::MockEvent', 'Test::Stream::Event');
 
 my $one = My::MockEvent->new(context => 'fake');
 
-can_ok('Test::Stream::Context', 'mockevent');
-
 done_testing;


### PR DESCRIPTION
Fixed #555

This removes the magic event-methods from Context and instead adds
send_event(...). There are still shortcut methods for the main events,
but they are not magic. This also removes the autoload.

(Note: Finished this yesterday, but forgot to commit+push, doing so now
so someone can look at it)