### PR TITLE
skip zzz-check-breaks if no META.* file in place

### DIFF
--- a/t/zzz-check-breaks.t
+++ b/t/zzz-check-breaks.t
@@ -13,7 +13,15 @@ eval {
     1
 } or plan skip_all => 'breakage test requires CPAN::Meta, CPAN::Meta::Requirements and Module::Metadata';
 
-my $breaks = CPAN::Meta->load_file(-e 'MYMETA.json' ? 'MYMETA.json' : 'META.json')->custom('x_breaks');
+my $metafile = -e 'MYMETA.json' ? 'MYMETA.json'
+             : -e 'META.json'   ? 'META.json'
+             :                    undef;
+
+unless ($metafile) {
+  plan skip_all => "can't check breakages without some META file";
+}
+
+my $breaks = CPAN::Meta->load_file($metafile)->custom('x_breaks');
 my $reqs = CPAN::Meta::Requirements->new;
 $reqs->add_string_requirement($_, $breaks->{$_}) foreach keys %$breaks;
 


### PR DESCRIPTION
...otherwise, prove fails in a fresh checkout.