### PR TITLE
optimize ok() callstack

### DIFF
--- a/lib/Test/More.pm
+++ b/lib/Test/More.pm
@@ -88,25 +88,19 @@ sub plan {
 }
 
 sub done_testing {
-    my ($num) = @_;
-    my $ctx = context();
-    $ctx->done_testing($num);
+    context()->done_testing(shift);
 }
 
 sub is($$;$) {
-    my ($got, $want, $name) = @_;
-    my $ctx = context();
-    my ($ok, @diag) = tmt->is_eq($got, $want);
-    $ctx->ok($ok, $name, \@diag);
-    return $ok;
+    #context must be stickied to a lexical or temp on perl stack, so both is_eq
+    #and send_event can use the cached weak global
+    my ($cxt, $ok, @diag) = (context(), tmt->is_eq(shift, shift));
+    $cxt->send_event('Ok', pass => $ok, name => shift, diag => \@diag), return $ok;
 }
 
 sub isnt ($$;$) {
-    my ($got, $forbid, $name) = @_;
-    my $ctx = context();
-    my ($ok, @diag) = tmt->isnt_eq($got, $forbid);
-    $ctx->ok($ok, $name, \@diag);
-    return $ok;
+    my ($cxt, $ok, @diag) = (context(), tmt->isnt_eq(shift, shift));
+    $cxt->send_event('Ok', pass => $ok, name => shift, diag => \@diag), return $ok;
 }
 
 {

--- a/lib/Test/More.pm
+++ b/lib/Test/More.pm
@@ -70,16 +70,8 @@ sub import_extra { 1 };
 sub builder { Test::Builder->new }
 
 sub ok ($;$) {
-    my ($test, $name) = @_;
-    my $ctx  = context();
-    if($test) {
-        $ctx->ok(1, $name);
-        return 1;
-    }
-    else {
-        $ctx->ok(0, $name);
-        return 0;
-    }
+    my $ret;
+    context()->send_event('Ok', pass => ($ret = shift), name => shift), return $ret;
 }
 
 sub plan {

--- a/lib/Test/Stream/Context.pm
+++ b/lib/Test/Stream/Context.pm
@@ -176,14 +176,11 @@ sub _find_context {
 
     if ($package) {
         no warnings 'uninitialized';
-        while ($package eq 'Test::Builder') {
-            ($package, $file, $line, $subname) = caller(++$level);
-        }
+        ($package, $file, $line, $subname) = caller(++$level)
+            while $package eq 'Test::Builder';
     }
     else {
-        while (!$package) {
-            ($package, $file, $line, $subname) = caller(--$level);
-        }
+        ($package, $file, $line, $subname) = caller(--$level) while !$package;
     }
 
     return unless $package;
@@ -363,9 +360,7 @@ sub _parse_event {
 
 # Shortcuts
 sub ok {
-    my $self = shift;
-    my ($pass, $name, $diag) = @_;
-    $self->send_event('Ok', pass => $pass, name => $name, diag => $diag);
+    shift->send_event('Ok', pass => shift, name => shift, diag => shift);
 }
 
 sub note {

--- a/lib/Test/Stream/Util.pm
+++ b/lib/Test/Stream/Util.pm
@@ -180,14 +180,14 @@ sub is_dualvar($) {
 #}
 
 sub unoverload {
-    my $type = shift;
+    if(defined $overload::VERSION) {
+        my $type = shift;
 
-    protect { require overload };
-
-    for my $thing (@_) {
-        if (blessed $$thing) {
-            if (my $string_meth = overload::Method($$thing, $type)) {
-                $$thing = $$thing->$string_meth();
+        for my $thing (@_) {
+            if (blessed $$thing) {
+                if (my $string_meth = overload::Method($$thing, $type)) {
+                    $$thing = $$thing->$string_meth();
+                }
             }
         }
     }

--- a/t/Legacy/More.t
+++ b/t/Legacy/More.t
@@ -8,7 +8,7 @@ BEGIN {
 }
 
 use lib 't/Legacy/lib/';
-use Test::More tests => 54;
+use Test::More tests => 55;
 use Test::Builder;
 
 # Make sure we don't mess with $@ or $!.  Test at bottom.
@@ -22,7 +22,7 @@ is( $Dummy::VERSION, '0.01', 'use_ok() loads a module' );
 require_ok('Test::More');
 
 
-ok( 2 eq 2,             'two is two is two is two' );
+ok(ok( 2 eq 2,             'two is two is two is two' ), 'retval of ok matches ok bool arg');
 is(   "foo", "foo",       'foo is foo' );
 isnt( "foo", "bar",     'foo isnt bar');
 isn't("foo", "bar",     'foo isn\'t bar');

--- a/t/Legacy/is_deeply_fail.t
+++ b/t/Legacy/is_deeply_fail.t
@@ -19,6 +19,7 @@ Test::Builder->new->no_header(1);
 Test::Builder->new->no_ending(1);
 local $ENV{HARNESS_ACTIVE} = 0;
 
+use overload;
 
 # Can't use Test.pm, that's a 5.005 thing.
 package main;


### PR DESCRIPTION
reduce number of perl ops such as avoiding opening scopes. Test::More::ok
can never have a 3rd arg, so no need to pass it to send_event.