### PR TITLE
Stream/subtest forking

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,6 @@
 NEXT:
     * Allow subtests to take a pre-constructed block object
+    * Replace suprising fork in subtest behavior with unsuprising one
 
 1.301001_105:
     * Update list of known broken downstream modules

--- a/Changes
+++ b/Changes
@@ -1,3 +1,6 @@
+NEXT:
+    * Allow subtests to take a pre-constructed block object
+
 1.301001_105:
     * Update list of known broken downstream modules
     * Fix untriggered Srream/Exporter bug

--- a/lib/Test/Stream/Event.pm
+++ b/lib/Test/Stream/Event.pm
@@ -6,7 +6,7 @@ use Scalar::Util qw/blessed/;
 use Test::Stream::Carp qw/confess/;
 
 use Test::Stream::HashBase(
-    accessors => [qw/context created in_subtest/],
+    accessors => [qw/context created in_subtest in_subtest_id/],
     no_import => 1,
 );
 

--- a/lib/Test/Stream/Subtest.pm
+++ b/lib/Test/Stream/Subtest.pm
@@ -18,14 +18,21 @@ sub subtest {
 
     my $ctx = context();
 
-    $ctx->throw("subtest()'s second argument must be a code ref")
-        unless $code && 'CODE' eq reftype($code);
-
-    my $block = Test::Stream::Block->new(
-        name    => $name,
-        coderef => $code,
-        caller  => [caller(0)],
-    );
+    my $block;
+    if (blessed($code) && $code->isa('Test::Stream::Block')) {
+        $block = $code;
+    }
+    elsif (ref $code && 'CODE' eq reftype($code)) {
+        $block = Test::Stream::Block->new(
+            name    => $name,
+            coderef => $code,
+            caller  => [caller(0)],
+        );
+    }
+    else {
+        $ctx->throw("subtest()'s second argument must be a code ref")
+            unless $code && 'CODE' eq reftype($code);
+    }
 
     $ctx->note("Subtest: $name")
         if $ctx->hub->subtest_tap_instant;

--- a/lib/Test/Stream/Subtest.pm
+++ b/lib/Test/Stream/Subtest.pm
@@ -49,8 +49,10 @@ sub subtest {
 
         return if $st->{early_return};
 
-        $ctx->set;
         my $hub = $ctx->hub;
+        $hub->fork_cull();
+
+        $ctx->set;
         $ctx->done_testing unless $hub->plan || $hub->ended;
 
         require Test::Stream::ExitMagic;

--- a/t/Legacy/fork_in_subtest.t
+++ b/t/Legacy/fork_in_subtest.t
@@ -5,22 +5,20 @@ use Test::CanFork;
 
 use Test::Stream 'enable_fork';
 use Test::More;
-# This just goes to show how silly forking inside a subtest would actually
-# be....
 
 ok(1, "fine $$");
 
 my $pid;
 subtest my_subtest => sub {
     ok(1, "inside 1 | $$");
+
     $pid = fork();
     ok(1, "inside 2 | $$");
+
+    exit 0 unless $pid;
+    waitpid($pid, 0);
 };
 
-if($pid) {
-    waitpid($pid, 0);
+ok(1, "after $$");
 
-    ok(1, "after $$");
-
-    done_testing;
-}
+done_testing;


### PR DESCRIPTION
This pull request introduces a saner behavior when forking inside a subtest.

This was accomplished by prefixing proc/thread ids of the proc/thread that should recieve the event to the event filename. Different procs and threads will only cull events sent to them.