### PR TITLE
Split subtest_tap into buffering and spec

### DIFF
--- a/lib/Test/Stream/Subtest.pm
+++ b/lib/Test/Stream/Subtest.pm
@@ -35,7 +35,7 @@ sub subtest {
     }
 
     $ctx->note("Subtest: $name")
-        if $ctx->hub->subtest_tap_instant;
+        unless $ctx->hub->subtest_buffering;
 
     my $st = $ctx->subtest_start($name);
 
@@ -97,8 +97,8 @@ This is almost certainly not what you wanted. Did you fork and forget to exit?
         events       => $st->{events},
         exception    => $st->{exception},
         early_return => $st->{early_return},
-        delayed      => $st->{delayed},
-        instant      => $st->{instant},
+        buffer       => $st->{buffer},
+        spec         => $st->{spec},
     );
 
     die $err unless $succ;

--- a/t/Test-Stream.t
+++ b/t/Test-Stream.t
@@ -11,7 +11,7 @@ use Test::Stream qw{
     state_count state_failed state_plan state_ended is_passing
     current_hub
 
-    disable_tap enable_tap subtest_tap_instant subtest_tap_delayed tap_encoding
+    disable_tap enable_tap subtest_buffering subtest_spec tap_encoding
     enable_numbers disable_numbers set_tap_outputs get_tap_outputs
 };
 
@@ -32,7 +32,7 @@ can_ok(__PACKAGE__, qw{
     state_count state_failed state_plan state_ended is_passing
     current_hub
 
-    disable_tap enable_tap subtest_tap_instant subtest_tap_delayed tap_encoding
+    disable_tap enable_tap subtest_buffering subtest_spec tap_encoding
     enable_numbers disable_numbers set_tap_outputs get_tap_outputs
 });
 
@@ -286,10 +286,14 @@ intercept {
     enable_numbers();
     ok(1, "pass");
 
-    subtest_tap_instant();
+    subtest_spec('legacy');
     subtest foo => sub { ok(1, 'pass') };
 
-    subtest_tap_delayed();
+    subtest_spec('block');
+    subtest foo => sub { ok(1, 'pass') };
+
+    subtest_spec('legacy');
+    subtest_buffering(1);
     subtest foo => sub { ok(1, 'pass') };
 };
 
@@ -311,6 +315,10 @@ ok 7 - foo {
     ok 1 - pass
     1..1
 }
+ok 8 - foo
+    ok 1 - pass
+    1..1
+# End Subtest: 8 - foo
 EOT
 
 is( $utf8, <<EOT, "got utf8 TAP output");


### PR DESCRIPTION
Fix #579

subtest_tap really should be 2 options, one for buffering subtest
results, one for setting the subtest renderign spec.