### PR TITLE
Add support for alternative concurrency models/drivers

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,6 @@
+NEXT:
+    * Allow alternative concurrency models/drivers
+
 1.301001_107:
     * Fix broken threading/forking on win32 introduced in _106
     * Make sure ALL tests run for older perls

--- a/MANIFEST
+++ b/MANIFEST
@@ -21,6 +21,8 @@ lib/Test/Stream.pm
 lib/Test/Stream/Architecture.pod
 lib/Test/Stream/Block.pm
 lib/Test/Stream/Carp.pm
+lib/Test/Stream/Concurrency.pm
+lib/Test/Stream/Concurrency/Files.pm
 lib/Test/Stream/Context.pm
 lib/Test/Stream/Design.pod
 lib/Test/Stream/Event.pm

--- a/lib/Test/Stream.pm
+++ b/lib/Test/Stream.pm
@@ -161,6 +161,10 @@ sub before_import {
             $hub->io_sets->init_encoding($encoding);
             $meta->{+ENCODING} = $encoding;
         }
+        elsif ($item eq 'concurrency') {
+            my $model = $list->[$idx++];
+            $hub->use_fork(ref $model ? @$model : $model);
+        }
         elsif ($item eq 'enable_fork') {
             $hub->use_fork;
         }
@@ -178,7 +182,7 @@ sub cull            { shared()->fork_cull()        }
 sub listen(&)       { shared()->listen($_[0])      }
 sub munge(&)        { shared()->munge($_[0])       }
 sub follow_up(&)    { shared()->follow_up($_[0])   }
-sub enable_forking  { shared()->use_fork()         }
+sub enable_forking  { shared()->use_fork(@_)       }
 sub disable_tap     { shared()->set_use_tap(0)     }
 sub enable_tap      { shared()->set_use_tap(1)     }
 sub enable_numbers  { shared()->set_use_numbers(1) }
@@ -374,7 +378,24 @@ The 'block' spec forces buffering, it wraps results in a block:
         1..2
     # }
 
+=item concurrency => []
+
+=item concurrency => 'Test::Stream::Concurrency::MODEL'
+
+=item concurrency => ['Test::Stream::Concurrency::MODEL1', 'FALLBACK', ...]
+
+Enable concurrency, and specify the model. If no model is provided (empty
+array) L<Test::Stream::Concurrency::Files> is assumed. All specified models are
+tried in order until one is found that works on the current platform. If none
+work the fallback of L<Test::Stream::Concurrency::Files> is used.
+
 =item 'enable_fork'
+
+Currently this is the same as
+C<< use Test::Stream concurrency => 'Test::Stream::Concurrency::Files' >>.
+However we reserve the right to alter the default concurrency models at any
+time, if it matters to you then you should specify one using the C<concurrency>
+argument.
 
 Turns on support for code that forks. This is not activated by default because
 it adds ~30ms to the Test::More compile-time, which can really add up in large

--- a/lib/Test/Stream/Concurrency.pm
+++ b/lib/Test/Stream/Concurrency.pm
@@ -1,0 +1,295 @@
+package Test::Stream::Concurrency;
+use strict;
+use warnings;
+
+use Scalar::Util qw/blessed/;
+use Test::Stream::Util qw/try/;
+
+use Carp qw/confess/;
+
+sub spawn {
+    for my $mod (@_) {
+        # This is a method that can be called on us or subclasses.
+        next if $mod eq __PACKAGE__;
+        my $file = $mod;
+        $file =~ s{::}{/}g;
+        $file .= ".pm";
+        my ($ok, $err) = try { require $file };
+        next unless $ok;
+        next unless $mod->is_viable();
+        my $instance = $mod->new() || next;
+        return $instance;
+    }
+
+    return undef;
+}
+
+for my $meth (qw/is_viable new send cull/) {
+    no strict 'refs';
+    *$meth = sub {
+        my $thing = shift;
+        my $class = blessed($thing) || $thing;
+        confess "'$class' did not define the required method '$meth'."
+    };
+}
+
+sub cleanup { };
+
+1;
+
+__END__
+
+=pod
+
+=encoding UTF-8
+
+=head1 NAME
+
+Test::Stream::Concurrency - Base class for concurrency models in Test::Stream
+
+=head1 SYNOPSIS
+
+=head2 SPECIFYING MODELS
+
+    use Test::Stream concurrency => ['My::Concurrency::Model', 'My::Concurrency::Fallback', ...];
+
+=head2 WRITING MODELS
+
+    package My::Concurrency::Model;
+    use strict;
+    use warnings;
+
+    use base 'Test::Stream::Concurrency';
+
+    # Checks to verify this model works in the current environment
+    sub is_viable {
+        return 1 unless $^O ne 'SUPPORTED_PLATFORM';
+        return 1 unless $ENV{NO_MODEL};
+        return 0;
+    }
+
+    # Creates a new instance
+    sub new { ... }
+
+    sub send {
+        my $self = shift;
+        my %params = @_;
+
+        # arrayrefs with process-id and thread-id
+        my $dest = $params{dest}; # where to send the events
+        my $orig = $params{orig}; # usually current proc-id and thread-id
+
+        # arrayref of events to send
+        my $events = $param{events};
+
+        ... # Here is where you send the events to the other thread/proc
+    }
+
+    sub cull {
+        my $self = shift;
+
+        # This tells us the pid and thread id we think we are, only cull
+        # results intended for this combination.
+        my ($pid, $tid) = @_; # proc-id and thread-id
+
+        my @events = ...; # Here is where you get the events
+
+        return @events;
+    }
+
+    sub cleanup {
+        my $self = shift;
+        my ($pid, $tid) = @_;
+
+        ... # any code you need to run AFTER all tests are complete. This is
+        ... # called by the hub's destructor.
+    }
+
+    1;
+
+=head1 CLASS METHODS
+
+=head1 METHODS SUBCLASSES ARE EXPECTED TO HAVE
+
+=head2 SUBCLASSES MUST IMPLEMENT
+
+=over 4
+
+=item $class->is_viable()
+
+This must be a class method. This method should return true if the concurrency
+model is expected to work in the current environment. If the concurrency model
+is not viable in the current environment it should return 0.
+
+    sub is_viable {
+        return 1 unless $^O ne 'SUPPORTED_PLATFORM';
+        return 1 unless $ENV{NO_MODEL};
+        return 0;
+    }
+
+=item $sync = $class->new()
+
+Create a new instance of the concurrency model. This should not require any
+arguments.
+
+=item $sync->send(dest => [$DPID, $DTID], orig => [$$, get_tid()], events => \@events);
+
+Used to send events from the current thread/proc to the destination
+thread/proc. The C<dest> argument will always be an arrayref with the proc-id
+and thread-id to which the events should be sent. The C<orig> argument will
+always have the proc-id and thread-id that the events are from, usually the
+current pid and tid. The c<events> argument will always be an arrayref of
+events to send.
+
+    sub send {
+        my $self = shift;
+        my %params = @_;
+
+        # arrayrefs with process-id and thread-id
+        my $dest = $params{dest}; # where to send the events
+        my $orig = $params{orig}; # usually current proc-id and thread-id
+
+        # arrayref of events to send
+        my $events = $param{events};
+
+        ... # Here is where you send the events to the other thread/proc
+    }
+
+=item @events = $sync->cull($pid, $tid)
+
+This is used to collect results sent by another process or thread. The argument
+are the proc-id and thread-id that should be used to identify what events
+belong to us, these correspond to the C<dest> argument of C<< $sync->send() >>.
+These will usually be the current proc-id and thread-id, but they may not be if
+someone is doing something clever.
+
+    sub cull {
+        my $self = shift;
+
+        # This tells us the pid and thread id we think we are, only cull
+        # results intended for this combination.
+        my ($pid, $tid) = @_; # proc-id and thread-id
+
+        my @events = ...; # Here is where you get the events
+
+        return @events;
+    }
+
+=back
+
+=head2 SUBCLASSES MAY IMPLEMENT
+
+=over 4
+
+=item $sync->cleanup($pid, $tid)
+
+Used for any final cleanup tasks. This is called by the L<Test::Stream:Hub>
+objects destructor.
+
+    sub cleanup {
+        my $self = shift;
+        my ($pid, $tid) = @_;
+
+        ... # any code you need to run AFTER all tests are complete. This is
+        ... # called by the hub's destructor.
+    }
+
+=back
+
+=head1 SOURCE
+
+The source code repository for Test::More can be found at
+F<http://github.com/Test-More/test-more/>.
+
+=head1 MAINTAINER
+
+=over 4
+
+=item Chad Granum E<lt>exodist@cpan.orgE<gt>
+
+=back
+
+=head1 AUTHORS
+
+The following people have all contributed to the Test-More dist (sorted using
+VIM's sort function).
+
+=over 4
+
+=item Chad Granum E<lt>exodist@cpan.orgE<gt>
+
+=item Fergal Daly E<lt>fergal@esatclear.ie>E<gt>
+
+=item Mark Fowler E<lt>mark@twoshortplanks.comE<gt>
+
+=item Michael G Schwern E<lt>schwern@pobox.comE<gt>
+
+=item 唐鳳
+
+=back
+
+=head1 COPYRIGHT
+
+There has been a lot of code migration between modules,
+here are all the original copyrights together:
+
+=over 4
+
+=item Test::Stream
+
+=item Test::Stream::Tester
+
+Copyright 2015 Chad Granum E<lt>exodist7@gmail.comE<gt>.
+
+This program is free software; you can redistribute it and/or
+modify it under the same terms as Perl itself.
+
+See F<http://www.perl.com/perl/misc/Artistic.html>
+
+=item Test::Simple
+
+=item Test::More
+
+=item Test::Builder
+
+Originally authored by Michael G Schwern E<lt>schwern@pobox.comE<gt> with much
+inspiration from Joshua Pritikin's Test module and lots of help from Barrie
+Slaymaker, Tony Bowden, blackstar.co.uk, chromatic, Fergal Daly and the perl-qa
+gang.
+
+Idea by Tony Bowden and Paul Johnson, code by Michael G Schwern
+E<lt>schwern@pobox.comE<gt>, wardrobe by Calvin Klein.
+
+Copyright 2001-2008 by Michael G Schwern E<lt>schwern@pobox.comE<gt>.
+
+This program is free software; you can redistribute it and/or
+modify it under the same terms as Perl itself.
+
+See F<http://www.perl.com/perl/misc/Artistic.html>
+
+=item Test::use::ok
+
+To the extent possible under law, 唐鳳 has waived all copyright and related
+or neighboring rights to L<Test-use-ok>.
+
+This work is published from Taiwan.
+
+L<http://creativecommons.org/publicdomain/zero/1.0>
+
+=item Test::Tester
+
+This module is copyright 2005 Fergal Daly <fergal@esatclear.ie>, some parts
+are based on other people's work.
+
+Under the same license as Perl itself
+
+See http://www.perl.com/perl/misc/Artistic.html
+
+=item Test::Builder::Tester
+
+Copyright Mark Fowler E<lt>mark@twoshortplanks.comE<gt> 2002, 2004.
+
+This program is free software; you can redistribute it
+and/or modify it under the same terms as Perl itself.
+
+=back

--- a/lib/Test/Stream/Concurrency/Files.pm
+++ b/lib/Test/Stream/Concurrency/Files.pm
@@ -1,0 +1,240 @@
+package Test::Stream::Concurrency::Files;
+use strict;
+use warnings;
+
+use Test::Stream::HashBase(
+    accessors => [qw/tempdir event_id/]
+);
+
+use base 'Test::Stream::Concurrency';
+
+use File::Temp;
+use Storable;
+
+use Carp qw/confess/;
+use Test::Stream::Util qw/try/;
+
+# I am not yet aware of any platforms on which this does not work.
+sub is_viable { 1 }
+
+sub init {
+    my $self = shift;
+
+    my $tmpdir = File::Temp::tempdir(CLEANUP => 0);
+    confess "Could not get a temp dir" unless $tmpdir;
+
+    if ($^O eq 'VMS') {
+        require VMS::Filespec;
+        $tmpdir = VMS::Filespec::unixify($tmpdir);
+    }
+
+    $self->{+TEMPDIR} = $tmpdir;
+
+    return $self;
+}
+
+sub send {
+    my $self = shift;
+    my %params = @_;
+
+    my $orig = join '-', @{$params{orig}};
+    my $dest = join '-', @{$params{dest}};
+    my $events = $params{events};
+
+    my $route = "$dest-$orig";
+
+    my $tempdir = $self->{+TEMPDIR};
+
+    for my $event (@$events) {
+        next unless $event;
+
+        # First write the file, then rename it so that it is not read before it is ready.
+        my $name =  $tempdir . "/$route-" . ($self->{+EVENT_ID}++);
+        my ($ret, $err) = try { Storable::store($event, $name) };
+        # Temporary to debug an error on one cpan-testers box
+        unless ($ret) {
+            require Data::Dumper;
+            confess(Data::Dumper::Dumper({ error => $err, event => $event}));
+        }
+        rename($name, "$name.ready") || confess "Could not rename file '$name' -> '$name.ready'";
+    }
+}
+
+sub cull {
+    my $self = shift;
+    my $prefix = join '-', @_;
+
+    my $tempdir = $self->{+TEMPDIR};
+
+    opendir(my $dh, $tempdir) || confess "could not open temp dir ($tempdir)!";
+
+    my @out;
+    my @files = sort readdir($dh);
+    for my $file (@files) {
+        next if $file =~ m/^\.+$/;
+        next unless $file =~ m/^\Q$prefix\E-.*\.ready$/;
+
+        # Untaint the path.
+        my $full = "$tempdir/$file";
+        ($full) = ($full =~ m/^(.*)$/gs);
+
+        my $obj = Storable::retrieve($full);
+        confess "Empty event object found '$full'" unless $obj;
+
+        if ($ENV{TEST_KEEP_TMP_DIR}) {
+            rename($full, "$full.complete")
+                || confess "Could not rename file '$full', '$full.complete'";
+        }
+        else {
+            unlink($full) || die "Could not unlink file: $file";
+        }
+
+        push @out => $obj;
+    }
+
+    closedir($dh);
+    return @out;
+}
+
+sub cleanup {
+    my $self = shift;
+
+    my $tempdir = $self->{+TEMPDIR};
+
+    if ($ENV{TEST_KEEP_TMP_DIR}) {
+        print STDERR "# Not removing temp dir: $tempdir\n";
+        return;
+    }
+
+    opendir(my $dh, $tempdir) || confess "Could not open temp dir! ($tempdir)";
+    while(my $file = readdir($dh)) {
+        next if $file =~ m/^\.+$/;
+        next if $file =~ m/\.complete$/;
+        die "Unculled event! You ran tests in a child process, but never pulled them in!\n";
+    }
+    closedir($dh);
+
+    return if $ENV{TEST_KEEP_TMP_DIR};
+
+    rmdir($tempdir) || warn "Could not remove temp dir ($tempdir)";
+}
+
+1;
+
+__END__
+
+=pod
+
+=encoding UTF-8
+
+=head1 NAME
+
+Test::Stream::Concurrency::Files - Temp dir + Files concurrency model.
+
+=head1 DESCRIPTION
+
+This is the default, and fallback concurrency model for L<Test::Stream>. This
+sends events between processes and threads using serialized files in a
+temporary directory. This is not particularily fast, but it works everywhere.
+
+=head1 SYNOPSIS
+
+    use Test::Stream concurrency => 'Test::Stream::Concurrency::Files';
+
+=head1 SOURCE
+
+The source code repository for Test::More can be found at
+F<http://github.com/Test-More/test-more/>.
+
+=head1 MAINTAINER
+
+=over 4
+
+=item Chad Granum E<lt>exodist@cpan.orgE<gt>
+
+=back
+
+=head1 AUTHORS
+
+The following people have all contributed to the Test-More dist (sorted using
+VIM's sort function).
+
+=over 4
+
+=item Chad Granum E<lt>exodist@cpan.orgE<gt>
+
+=item Fergal Daly E<lt>fergal@esatclear.ie>E<gt>
+
+=item Mark Fowler E<lt>mark@twoshortplanks.comE<gt>
+
+=item Michael G Schwern E<lt>schwern@pobox.comE<gt>
+
+=item 唐鳳
+
+=back
+
+=head1 COPYRIGHT
+
+There has been a lot of code migration between modules,
+here are all the original copyrights together:
+
+=over 4
+
+=item Test::Stream
+
+=item Test::Stream::Tester
+
+Copyright 2015 Chad Granum E<lt>exodist7@gmail.comE<gt>.
+
+This program is free software; you can redistribute it and/or
+modify it under the same terms as Perl itself.
+
+See F<http://www.perl.com/perl/misc/Artistic.html>
+
+=item Test::Simple
+
+=item Test::More
+
+=item Test::Builder
+
+Originally authored by Michael G Schwern E<lt>schwern@pobox.comE<gt> with much
+inspiration from Joshua Pritikin's Test module and lots of help from Barrie
+Slaymaker, Tony Bowden, blackstar.co.uk, chromatic, Fergal Daly and the perl-qa
+gang.
+
+Idea by Tony Bowden and Paul Johnson, code by Michael G Schwern
+E<lt>schwern@pobox.comE<gt>, wardrobe by Calvin Klein.
+
+Copyright 2001-2008 by Michael G Schwern E<lt>schwern@pobox.comE<gt>.
+
+This program is free software; you can redistribute it and/or
+modify it under the same terms as Perl itself.
+
+See F<http://www.perl.com/perl/misc/Artistic.html>
+
+=item Test::use::ok
+
+To the extent possible under law, 唐鳳 has waived all copyright and related
+or neighboring rights to L<Test-use-ok>.
+
+This work is published from Taiwan.
+
+L<http://creativecommons.org/publicdomain/zero/1.0>
+
+=item Test::Tester
+
+This module is copyright 2005 Fergal Daly <fergal@esatclear.ie>, some parts
+are based on other people's work.
+
+Under the same license as Perl itself
+
+See http://www.perl.com/perl/misc/Artistic.html
+
+=item Test::Builder::Tester
+
+Copyright Mark Fowler E<lt>mark@twoshortplanks.comE<gt> 2002, 2004.
+
+This program is free software; you can redistribute it
+and/or modify it under the same terms as Perl itself.
+
+=back


### PR DESCRIPTION
Will not merge this until after the initial release, it is too much churn. Wrote this because of a request from @Tux.