### PR TITLE
fix calling get accessor instead of set in Test::Stream::clear

### DIFF
--- a/lib/Test/Stream.pm
+++ b/lib/Test/Stream.pm
@@ -41,7 +41,7 @@ sub shared {
 }
 
 sub clear {
-    $root->no_ending(1);
+    $root->set_no_ending(1);
     $root  = undef;
     $magic = undef;
     @stack = ();


### PR DESCRIPTION
IDK why no tests ever caught this mistake.