### PR TITLE
audit use lines

### DIFF
--- a/lib/Test/Builder.pm
+++ b/lib/Test/Builder.pm
@@ -9,14 +9,12 @@ $VERSION = eval $VERSION;    ## no critic (BuiltinFunctions::ProhibitStringyEval
 
 
 use Test::Stream 1.301001 ();
-use Test::Stream::Hub;
-use Test::Stream::Toolset;
-use Test::Stream::Context;
-use Test::Stream::Carp qw/confess/;
+use Test::Stream::Hub ();
+use Test::Stream::Toolset ();
+use Test::Stream::Context ();
 use Test::Stream::Meta qw/MODERN/;
 
-use Test::Stream::Util qw/try protect unoverload_str is_regex/;
-use Scalar::Util qw/blessed reftype/;
+use Test::Stream::Util qw/protect unoverload_str is_regex/;
 
 use Test::More::Tools;
 

--- a/lib/Test/Builder/Module.pm
+++ b/lib/Test/Builder/Module.pm
@@ -3,7 +3,7 @@ package Test::Builder::Module;
 use strict;
 
 use Test::Stream 1.301001 ();
-use Test::Builder 0.99;
+use Test::Builder 0.99 ();
 
 require Exporter;
 our @ISA = qw(Exporter);

--- a/lib/Test/Builder/Tester.pm
+++ b/lib/Test/Builder/Tester.pm
@@ -5,7 +5,7 @@ our $VERSION = '1.301001_107';
 $VERSION = eval $VERSION;    ## no critic (BuiltinFunctions::ProhibitStringyEval)
 
 use Test::Stream 1.301001 ();
-use Test::Builder 1.301001;
+use Test::Builder 1.301001 ();
 use Symbol;
 use Test::Stream::Carp qw/croak/;
 use Test::Stream::Context qw/context/;
@@ -66,8 +66,8 @@ output.
 # make us an exporter
 ###
 
-use Test::Stream::Toolset;
-use Test::Stream::Exporter;
+use Test::Stream::Toolset qw/init_tester/;
+use Test::Stream::Exporter qw/import default_exports/;
 default_exports qw/test_out test_err test_fail test_diag test_test line_num/;
 Test::Stream::Exporter->cleanup;
 

--- a/lib/Test/Builder/Tester.pm
+++ b/lib/Test/Builder/Tester.pm
@@ -67,8 +67,8 @@ output.
 ###
 
 use Test::Stream::Toolset qw/init_tester/;
-use Test::Stream::Exporter qw/import default_exports/;
-default_exports qw/test_out test_err test_fail test_diag test_test line_num/;
+use Test::Stream::Exporter qw/import/;
+Test::Stream::Exporter::default_exports qw/test_out test_err test_fail test_diag test_test line_num/;
 Test::Stream::Exporter->cleanup;
 
 sub before_import {

--- a/lib/Test/More.pm
+++ b/lib/Test/More.pm
@@ -19,13 +19,11 @@ use Test::More::DeepCheck::Strict ();
 
 use Test::Builder ();
 
-use Test::Stream::Exporter qw/
-    default_export default_exports export_to
-/;
+use Test::Stream::Exporter qw/export_to/;
 
 our $TODO;
-default_export '$TODO' => \$TODO;
-default_exports qw{
+Test::Stream::Exporter::default_export '$TODO' => \$TODO;
+Test::Stream::Exporter::default_exports qw{
     plan done_testing
 
     ok

--- a/lib/Test/More.pm
+++ b/lib/Test/More.pm
@@ -8,20 +8,19 @@ our $VERSION = '1.301001_107';
 $VERSION = eval $VERSION;    ## no critic (BuiltinFunctions::ProhibitStringyEval)
 
 use Test::Stream 1.301001 ();
-use Test::Stream::Util qw/protect try spoof/;
-use Test::Stream::Toolset qw/is_tester init_tester context before_import/;
+use Test::Stream::Util qw/spoof/;
+use Test::Stream::Toolset qw/context before_import/;
 use Test::Stream::Subtest qw/subtest/;
 
-use Test::Stream::Carp qw/croak carp/;
-use Scalar::Util qw/blessed/;
+use Test::Stream::Carp qw/croak/;
 
 use Test::More::Tools;
-use Test::More::DeepCheck::Strict;
+use Test::More::DeepCheck::Strict ();
 
-use Test::Builder;
+use Test::Builder ();
 
 use Test::Stream::Exporter qw/
-    default_export default_exports export_to export_to_level
+    default_export default_exports export_to
 /;
 
 our $TODO;

--- a/lib/Test/More/DeepCheck/Strict.pm
+++ b/lib/Test/More/DeepCheck/Strict.pm
@@ -5,7 +5,7 @@ use warnings;
 use Scalar::Util qw/reftype/;
 use Test::More::Tools;
 use Test::Stream::Carp qw/cluck confess/;
-use Test::Stream::Util qw/try unoverload_str is_regex/;
+use Test::Stream::Util qw/unoverload_str is_regex/;
 
 use Test::Stream::HashBase(
     base => 'Test::More::DeepCheck',

--- a/lib/Test/More/Tools.pm
+++ b/lib/Test/More/Tools.pm
@@ -4,8 +4,8 @@ use warnings;
 
 use Test::Stream::Context;
 
-use Test::Stream::Exporter qw/import default_exports/;
-default_exports qw/tmt/;
+use Test::Stream::Exporter qw/import/;
+Test::Stream::Exporter::default_exports qw/tmt/;
 Test::Stream::Exporter->cleanup;
 
 use Test::Stream::Util qw/try protect is_regex unoverload_str unoverload_num/;

--- a/lib/Test/More/Tools.pm
+++ b/lib/Test/More/Tools.pm
@@ -4,12 +4,12 @@ use warnings;
 
 use Test::Stream::Context;
 
-use Test::Stream::Exporter;
+use Test::Stream::Exporter qw/import default_exports/;
 default_exports qw/tmt/;
 Test::Stream::Exporter->cleanup;
 
 use Test::Stream::Util qw/try protect is_regex unoverload_str unoverload_num/;
-use Scalar::Util qw/blessed reftype/;
+use Scalar::Util qw/blessed/;
 
 sub tmt() { __PACKAGE__ }
 

--- a/lib/Test/MostlyLike.pm
+++ b/lib/Test/MostlyLike.pm
@@ -3,8 +3,8 @@ use strict;
 use warnings;
 
 use Test::Stream::Toolset qw/context/;
-use Test::Stream::Exporter qw/import default_exports/;
-default_exports qw/mostly_like/;
+use Test::Stream::Exporter qw/import/;
+Test::Stream::Exporter::default_exports qw/mostly_like/;
 Test::Stream::Exporter->cleanup;
 
 use Test::More::DeepCheck::Tolerant ();

--- a/lib/Test/MostlyLike.pm
+++ b/lib/Test/MostlyLike.pm
@@ -2,12 +2,12 @@ package Test::MostlyLike;
 use strict;
 use warnings;
 
-use Test::Stream::Toolset;
-use Test::Stream::Exporter;
+use Test::Stream::Toolset qw/context/;
+use Test::Stream::Exporter qw/import default_exports/;
 default_exports qw/mostly_like/;
 Test::Stream::Exporter->cleanup;
 
-use Test::More::DeepCheck::Tolerant;
+use Test::More::DeepCheck::Tolerant ();
 
 sub mostly_like {
     my ($got, $want, $name) = @_;

--- a/lib/Test/Simple.pm
+++ b/lib/Test/Simple.pm
@@ -12,8 +12,8 @@ use Test::Stream 1.301001_107 ();
 use Test::Stream::Toolset qw/init_tester context/;
 
 use Test::Builder ();
-use Test::Stream::Exporter qw/import default_exports/;
-default_exports qw/ok/;
+use Test::Stream::Exporter qw/import/;
+Test::Stream::Exporter::default_exports qw/ok/;
 Test::Stream::Exporter->cleanup;
 
 sub before_import {

--- a/lib/Test/Simple.pm
+++ b/lib/Test/Simple.pm
@@ -9,10 +9,10 @@ our $VERSION = '1.301001_107';
 $VERSION = eval $VERSION;    ## no critic (BuiltinFunctions::ProhibitStringyEval)
 
 use Test::Stream 1.301001_107 ();
-use Test::Stream::Toolset;
+use Test::Stream::Toolset qw/init_tester context/;
 
-use Test::Builder;
-use Test::Stream::Exporter;
+use Test::Builder ();
+use Test::Stream::Exporter qw/import default_exports/;
 default_exports qw/ok/;
 Test::Stream::Exporter->cleanup;
 

--- a/lib/Test/Stream.pm
+++ b/lib/Test/Stream.pm
@@ -109,9 +109,9 @@ BEGIN {
     *peek_todo     = \&Test::Stream::Context::peek_todo;
 }
 
-use Test::Stream::Exporter qw/default_exports exports import/;
-default_exports qw/context/;
-exports qw{
+use Test::Stream::Exporter qw/import/;
+Test::Stream::Exporter::default_exports qw/context/;
+Test::Stream::Exporter::exports qw{
     listen munge follow_up
     enable_forking cull
     peek_todo push_todo pop_todo set_todo inspect_todo

--- a/lib/Test/Stream.pm
+++ b/lib/Test/Stream.pm
@@ -5,18 +5,18 @@ use warnings;
 our $VERSION = '1.301001_107';
 $VERSION = eval $VERSION;    ## no critic (BuiltinFunctions::ProhibitStringyEval)
 
-use Test::Stream::Carp qw/croak confess carp/;
+use Test::Stream::Carp qw/croak/;
 use Test::Stream::Util qw/try/;
-use Test::Stream::Threads;
+use Test::Stream::Threads qw/get_tid/;
 
 ############################
 # {{{ Hub stack management #
 ############################
 
-use Test::Stream::Hub;
-use Test::Stream::Event::Finish;
-use Test::Stream::ExitMagic;
-use Test::Stream::ExitMagic::Context;
+use Test::Stream::Hub ();
+use Test::Stream::Event::Finish ();
+use Test::Stream::ExitMagic ();
+use Test::Stream::ExitMagic::Context ();
 
 # Do not repeat Test::Builders singleton error, these are lexical vars, not package vars.
 my ($root, @stack, $magic);
@@ -99,7 +99,6 @@ sub intercept {
 use Test::Stream::Context qw/context inspect_todo/;
 use Test::Stream::IOSets  qw/OUT_STD OUT_ERR OUT_TODO/;
 use Test::Stream::Meta    qw/MODERN ENCODING init_tester is_tester/;
-use Test::Stream::State   qw/PLAN COUNT FAILED ENDED LEGACY/;
 
 BEGIN {
     *peek_context  = \&Test::Stream::Context::peek;
@@ -110,7 +109,7 @@ BEGIN {
     *peek_todo     = \&Test::Stream::Context::peek_todo;
 }
 
-use Test::Stream::Exporter;
+use Test::Stream::Exporter qw/default_exports exports import/;
 default_exports qw/context/;
 exports qw{
     listen munge follow_up

--- a/lib/Test/Stream/Block.pm
+++ b/lib/Test/Stream/Block.pm
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 
 use Scalar::Util qw/blessed reftype/;
-use Test::Stream::Carp qw/confess carp/;
+use Test::Stream::Carp qw/confess/;
 
 use Test::Stream::HashBase(
     accessors => [qw/name coderef params caller deduced _start_line _end_line/],

--- a/lib/Test/Stream/Carp.pm
+++ b/lib/Test/Stream/Carp.pm
@@ -2,7 +2,7 @@ package Test::Stream::Carp;
 use strict;
 use warnings;
 
-use Test::Stream::Exporter;
+use Test::Stream::Exporter qw/export import/;
 
 export croak   => sub { require Carp; goto &Carp::croak };
 export confess => sub { require Carp; goto &Carp::confess };

--- a/lib/Test/Stream/Carp.pm
+++ b/lib/Test/Stream/Carp.pm
@@ -2,12 +2,12 @@ package Test::Stream::Carp;
 use strict;
 use warnings;
 
-use Test::Stream::Exporter qw/export import/;
+use Test::Stream::Exporter qw/import/;
 
-export croak   => sub { require Carp; goto &Carp::croak };
-export confess => sub { require Carp; goto &Carp::confess };
-export cluck   => sub { require Carp; goto &Carp::cluck };
-export carp    => sub { require Carp; goto &Carp::carp };
+Test::Stream::Exporter::export croak   => sub { require Carp; goto &Carp::croak };
+Test::Stream::Exporter::export confess => sub { require Carp; goto &Carp::confess };
+Test::Stream::Exporter::export cluck   => sub { require Carp; goto &Carp::cluck };
+Test::Stream::Exporter::export carp    => sub { require Carp; goto &Carp::carp };
 
 Test::Stream::Exporter->cleanup;
 

--- a/lib/Test/Stream/Context.pm
+++ b/lib/Test/Stream/Context.pm
@@ -14,9 +14,9 @@ use Test::Stream::HashBase(
     accessors => [qw/frame hub encoding in_todo todo modern pid skip diag_todo provider/],
 );
 
-use Test::Stream::Exporter qw/import default_exports exports/;
-default_exports qw/context/;
-exports qw/inspect_todo/;
+use Test::Stream::Exporter qw/import/;
+Test::Stream::Exporter::default_exports qw/context/;
+Test::Stream::Exporter::exports qw/inspect_todo/;
 Test::Stream::Exporter->cleanup();
 
 {

--- a/lib/Test/Stream/Context.pm
+++ b/lib/Test/Stream/Context.pm
@@ -14,7 +14,7 @@ use Test::Stream::HashBase(
     accessors => [qw/frame hub encoding in_todo todo modern pid skip diag_todo provider/],
 );
 
-use Test::Stream::Exporter qw/import export_to default_exports exports/;
+use Test::Stream::Exporter qw/import default_exports exports/;
 default_exports qw/context/;
 exports qw/inspect_todo/;
 Test::Stream::Exporter->cleanup();

--- a/lib/Test/Stream/Event/Diag.pm
+++ b/lib/Test/Stream/Event/Diag.pm
@@ -6,7 +6,6 @@ use Test::Stream::Event(
     accessors => [qw/message linked/],
 );
 
-use Test::Stream::Util qw/try/;
 use Scalar::Util qw/weaken/;
 use Test::Stream::Carp qw/confess/;
 

--- a/lib/Test/Stream/Event/Note.pm
+++ b/lib/Test/Stream/Event/Note.pm
@@ -6,8 +6,6 @@ use Test::Stream::Event(
     accessors  => [qw/message/],
 );
 
-use Test::Stream::Carp qw/confess/;
-
 sub init {
     $_[0]->SUPER::init();
     if (defined $_[0]->{+MESSAGE}) {

--- a/lib/Test/Stream/Event/Ok.pm
+++ b/lib/Test/Stream/Event/Ok.pm
@@ -6,7 +6,7 @@ use Scalar::Util qw/blessed/;
 use Test::Stream::Util qw/unoverload_str/;
 use Test::Stream::Carp qw/confess/;
 
-use Test::Stream::Event::Diag;
+use Test::Stream::Event::Diag ();
 
 use Test::Stream::Event(
     accessors => [qw/pass name diag effective_pass level/],

--- a/lib/Test/Stream/Event/Subtest.pm
+++ b/lib/Test/Stream/Event/Subtest.pm
@@ -2,9 +2,6 @@ package Test::Stream::Event::Subtest;
 use strict;
 use warnings;
 
-use Scalar::Util qw/blessed/;
-use Test::Stream::Carp qw/confess/;
-
 use Test::Stream::Event(
     base       => 'Test::Stream::Event::Ok',
     accessors  => [qw/state events exception early_return buffer spec/],

--- a/lib/Test/Stream/ExitMagic.pm
+++ b/lib/Test/Stream/ExitMagic.pm
@@ -2,7 +2,7 @@ package Test::Stream::ExitMagic;
 use strict;
 use warnings;
 
-use Test::Stream::ExitMagic::Context;
+use Test::Stream::ExitMagic::Context ();
 
 use Test::Stream::HashBase(
     accessors => [qw/pid done/],

--- a/lib/Test/Stream/Exporter.pm
+++ b/lib/Test/Stream/Exporter.pm
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 
 use Test::Stream::PackageUtil;
-use Test::Stream::Exporter::Meta;
+use Test::Stream::Exporter::Meta ();
 
 sub export;
 sub exports;

--- a/lib/Test/Stream/HashBase.pm
+++ b/lib/Test/Stream/HashBase.pm
@@ -2,9 +2,8 @@ package Test::Stream::HashBase;
 use strict;
 use warnings;
 
-use Test::Stream::HashBase::Meta;
-use Test::Stream::Carp qw/confess croak/;
-use Scalar::Util qw/blessed reftype/;
+use Test::Stream::HashBase::Meta ();
+use Test::Stream::Carp qw/croak/;
 
 use Test::Stream::Exporter();
 

--- a/lib/Test/Stream/Hub.pm
+++ b/lib/Test/Stream/Hub.pm
@@ -4,9 +4,9 @@ use warnings;
 
 use Test::Stream::Context qw/context/;
 use Test::Stream::Threads;
-use Test::Stream::IOSets;
+use Test::Stream::IOSets ();
 use Test::Stream::Util qw/try/;
-use Test::Stream::Carp qw/croak confess carp cluck/;
+use Test::Stream::Carp qw/croak confess cluck/;
 use Test::Stream::State qw/PLAN COUNT FAILED ENDED LEGACY/;
 
 use Test::Stream::HashBase(

--- a/lib/Test/Stream/IOSets.pm
+++ b/lib/Test/Stream/IOSets.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use Test::Stream::Util qw/protect/;
 
-use Test::Stream::Exporter;
+use Test::Stream::Exporter qw/exports import/;
 exports qw/
     OUT_STD OUT_ERR OUT_TODO
 /;

--- a/lib/Test/Stream/IOSets.pm
+++ b/lib/Test/Stream/IOSets.pm
@@ -4,8 +4,8 @@ use warnings;
 
 use Test::Stream::Util qw/protect/;
 
-use Test::Stream::Exporter qw/exports import/;
-exports qw/
+use Test::Stream::Exporter qw/import/;
+Test::Stream::Exporter::exports qw/
     OUT_STD OUT_ERR OUT_TODO
 /;
 Test::Stream::Exporter->cleanup;

--- a/lib/Test/Stream/Meta.pm
+++ b/lib/Test/Stream/Meta.pm
@@ -2,16 +2,13 @@ package Test::Stream::Meta;
 use strict;
 use warnings;
 
-use Scalar::Util();
-use Test::Stream::Util qw/protect/;
-
 use Test::Stream::HashBase(
     accessors => [qw/package encoding modern todo hub stash/],
 );
 
 use Test::Stream::PackageUtil;
 
-use Test::Stream::Exporter qw/import export_to default_exports/;
+use Test::Stream::Exporter qw/import default_exports/;
 default_exports qw{ is_tester init_tester };
 Test::Stream::Exporter->cleanup();
 

--- a/lib/Test/Stream/Meta.pm
+++ b/lib/Test/Stream/Meta.pm
@@ -8,8 +8,8 @@ use Test::Stream::HashBase(
 
 use Test::Stream::PackageUtil;
 
-use Test::Stream::Exporter qw/import default_exports/;
-default_exports qw{ is_tester init_tester };
+use Test::Stream::Exporter qw/import/;
+Test::Stream::Exporter::default_exports qw{ is_tester init_tester };
 Test::Stream::Exporter->cleanup();
 
 my %META;

--- a/lib/Test/Stream/Subtest.pm
+++ b/lib/Test/Stream/Subtest.pm
@@ -2,8 +2,8 @@ package Test::Stream::Subtest;
 use strict;
 use warnings;
 
-use Test::Stream::Exporter qw/default_exports import/;
-default_exports qw/subtest/;
+use Test::Stream::Exporter qw/import/;
+Test::Stream::Exporter::default_exports qw/subtest/;
 Test::Stream::Exporter->cleanup;
 
 use Test::Stream::Context qw/context/;

--- a/lib/Test/Stream/Subtest.pm
+++ b/lib/Test/Stream/Subtest.pm
@@ -2,7 +2,7 @@ package Test::Stream::Subtest;
 use strict;
 use warnings;
 
-use Test::Stream::Exporter;
+use Test::Stream::Exporter qw/default_exports import/;
 default_exports qw/subtest/;
 Test::Stream::Exporter->cleanup;
 
@@ -11,7 +11,7 @@ use Scalar::Util qw/reftype blessed/;
 use Test::Stream::Util qw/try/;
 use Test::Stream::Carp qw/confess/;
 
-use Test::Stream::Block;
+use Test::Stream::Block ();
 
 sub subtest {
     my ($name, $code, @args) = @_;

--- a/lib/Test/Stream/Tester.pm
+++ b/lib/Test/Stream/Tester.pm
@@ -10,13 +10,13 @@ use B;
 use Scalar::Util qw/blessed reftype/;
 use Test::Stream::Carp qw/croak carp/;
 
-use Test::Stream::Tester::Checks;
-use Test::Stream::Tester::Checks::Event;
-use Test::Stream::Tester::Events;
-use Test::Stream::Tester::Events::Event;
+use Test::Stream::Tester::Checks ();
+use Test::Stream::Tester::Checks::Event ();
+use Test::Stream::Tester::Events ();
+use Test::Stream::Tester::Events::Event ();
 
-use Test::Stream::Toolset;
-use Test::Stream::Exporter;
+use Test::Stream::Toolset qw/context/;
+use Test::Stream::Exporter qw/default_exports default_export import/;
 default_exports qw{
     intercept grab
 

--- a/lib/Test/Stream/Tester.pm
+++ b/lib/Test/Stream/Tester.pm
@@ -16,15 +16,15 @@ use Test::Stream::Tester::Events ();
 use Test::Stream::Tester::Events::Event ();
 
 use Test::Stream::Toolset qw/context/;
-use Test::Stream::Exporter qw/default_exports default_export import/;
-default_exports qw{
+use Test::Stream::Exporter qw/import/;
+Test::Stream::Exporter::default_exports qw{
     intercept grab
 
     events_are
     check event directive
 };
 
-default_export dir => \&directive;
+Test::Stream::Exporter::default_export dir => \&directive;
 Test::Stream::Exporter->cleanup;
 
 sub grab {

--- a/lib/Test/Stream/Tester/Checks.pm
+++ b/lib/Test/Stream/Tester/Checks.pm
@@ -2,7 +2,7 @@ package Test::Stream::Tester::Checks;
 use strict;
 use warnings;
 
-use Test::Stream::Carp qw/croak confess/;
+use Test::Stream::Carp qw/confess/;
 use Test::Stream::Util qw/is_regex/;
 
 use Scalar::Util qw/blessed reftype/;

--- a/lib/Test/Stream/Tester/Events.pm
+++ b/lib/Test/Stream/Tester/Events.pm
@@ -4,7 +4,7 @@ use warnings;
 
 use Scalar::Util qw/blessed/;
 
-use Test::Stream::Tester::Events::Event;
+use Test::Stream::Tester::Events::Event ();
 
 sub new {
     my $class = shift;

--- a/lib/Test/Stream/Threads.pm
+++ b/lib/Test/Stream/Threads.pm
@@ -20,8 +20,8 @@ BEGIN {
     }
 }
 
-use Test::Stream::Exporter qw/default_exports import/;
-default_exports qw/get_tid USE_THREADS/;
+use Test::Stream::Exporter qw/import/;
+Test::Stream::Exporter::default_exports qw/get_tid USE_THREADS/;
 Test::Stream::Exporter->cleanup;
 
 1;

--- a/lib/Test/Stream/Threads.pm
+++ b/lib/Test/Stream/Threads.pm
@@ -20,7 +20,7 @@ BEGIN {
     }
 }
 
-use Test::Stream::Exporter;
+use Test::Stream::Exporter qw/default_exports import/;
 default_exports qw/get_tid USE_THREADS/;
 Test::Stream::Exporter->cleanup;
 

--- a/lib/Test/Stream/Toolset.pm
+++ b/lib/Test/Stream/Toolset.pm
@@ -7,15 +7,15 @@ use Test::Stream::Meta    qw/is_tester init_tester/;
 use Test::Stream::Carp    qw/carp/;
 
 # Preload these so the autoload is not necessary
-use Test::Stream::Event::Bail;
-use Test::Stream::Event::Diag;
-use Test::Stream::Event::Finish;
-use Test::Stream::Event::Note;
-use Test::Stream::Event::Ok;
-use Test::Stream::Event::Plan;
-use Test::Stream::Event::Subtest;
+use Test::Stream::Event::Bail ();
+use Test::Stream::Event::Diag ();
+use Test::Stream::Event::Finish ();
+use Test::Stream::Event::Note ();
+use Test::Stream::Event::Ok ();
+use Test::Stream::Event::Plan ();
+use Test::Stream::Event::Subtest ();
 
-use Test::Stream::Exporter qw/import export_to default_exports export/;
+use Test::Stream::Exporter qw/import default_exports export/;
 default_exports qw/is_tester init_tester context/;
 
 export before_import => sub {

--- a/lib/Test/Stream/Toolset.pm
+++ b/lib/Test/Stream/Toolset.pm
@@ -15,10 +15,10 @@ use Test::Stream::Event::Ok ();
 use Test::Stream::Event::Plan ();
 use Test::Stream::Event::Subtest ();
 
-use Test::Stream::Exporter qw/import default_exports export/;
-default_exports qw/is_tester init_tester context/;
+use Test::Stream::Exporter qw/import/;
+Test::Stream::Exporter::default_exports qw/is_tester init_tester context/;
 
-export before_import => sub {
+Test::Stream::Exporter::export before_import => sub {
     my $class = shift;
     my ($importer, $list) = @_;
 

--- a/lib/Test/Stream/Util.pm
+++ b/lib/Test/Stream/Util.pm
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 
 use Scalar::Util qw/reftype blessed/;
-use Test::Stream::Exporter qw/import export_to exports/;
+use Test::Stream::Exporter qw/import exports/;
 use Test::Stream::Carp qw/croak/;
 
 exports qw{

--- a/lib/Test/Stream/Util.pm
+++ b/lib/Test/Stream/Util.pm
@@ -3,10 +3,10 @@ use strict;
 use warnings;
 
 use Scalar::Util qw/reftype blessed/;
-use Test::Stream::Exporter qw/import exports/;
+use Test::Stream::Exporter qw/import/;
 use Test::Stream::Carp qw/croak/;
 
-exports qw{
+Test::Stream::Exporter::exports qw{
     try protect spoof is_regex is_dualvar
     unoverload unoverload_str unoverload_num
     translate_filename

--- a/lib/Test/Tester.pm
+++ b/lib/Test/Tester.pm
@@ -6,10 +6,10 @@ package Test::Tester;
 #warn "Test::Tester is deprecated, see Test::Stream::Tester\n";
 
 use Test::Stream 1.301001 ();
-use Test::Builder 1.301001;
-use Test::Stream::Toolset;
-use Test::More::Tools;
-use Test::Tester::Capture;
+use Test::Builder 1.301001 ();
+use Test::Stream::Toolset qw/context/;
+use Test::More::Tools ();
+use Test::Tester::Capture ();
 
 require Exporter;
 


### PR DESCRIPTION
Either dont call import() by supplying "()". Remove the number of imports,
explictly specify the imports to decrease the number of new symbols (if
a module exports 1 symbol, no point of specifying that 1 symbol explictly).
If the module is really unused, delete the line.

Private Bytes (malloc pages) memory on Win32 of perl.exe dropped from
3,376KB to 3,368KB when running "perl -MTest::More -E"system 'pause'"".
Nytprof reported a drop of 287 less subroutines called for the entire
-MTest::More process. This is probably a 287 of per process, regardless of
tests run. It should improve startup time slightly, but "timeit" tool on
win32 has too low resolution (15 ms unit) for me to definitely say.