### PR TITLE
Changed pod about Test::Builder::Module.

### DIFF
--- a/lib/Test/Builder/Module.pm
+++ b/lib/Test/Builder/Module.pm
@@ -22,7 +22,7 @@ Test::Builder::Module - Base class for test modules
 
   my $CLASS = __PACKAGE__;
 
-  use base 'Test::Builder::Module';
+  use parent 'Test::Builder::Module';
   @EXPORT = qw(ok);
 
   sub ok ($;$) {


### PR DESCRIPTION
According to the perldoc of 'base' pragma, it has now been recommended
towards the 'parent' pragma.

parent module's core module of 5.10 or later, but for people to write a new module now it is better that had been written on the document as use the parent module.