### PR TITLE
do not remove dist.ini from the build

### DIFF
--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -71,7 +71,6 @@
 ^Test-Simple-
 ^Test2-*
 
-dist.ini
 TODO
 ^xt/
 


### PR DESCRIPTION
Its inclusion in the shipped distribution is helpful for diagnosing how things
in the build came to be, without having to hunt down the git repository.