### PR TITLE
Breaks Test::Alien prior to 0.05

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -33,6 +33,7 @@ Log::Dispatch::Config::TestLog = <= 0.02
 Net::BitTorrent                = <= 0.052
 Test::Able                     = <= 0.11
 Test::Aggregate                = <= 0.373
+Test::Alien                    = <= 0.04
 Test::Builder::Clutch          = <= 0.07
 Test::Clustericious::Cluster   = <= 0.30
 Test::Dist::VersionSync        = <= 1.1.4


### PR DESCRIPTION
0.01 - 0.04 of Test::Alien used Test::Stream, so you can get some events from both Test2 and Test::Alien which confuses things.