### PR TITLE
Load time micro optimizations

### DIFF
--- a/lib/Test/Builder.pm
+++ b/lib/Test/Builder.pm
@@ -12,8 +12,6 @@ BEGIN {
     }
 }
 
-use overload();
-
 use Scalar::Util qw/blessed reftype weaken/;
 
 use Test2::Util qw/USE_THREADS try get_tid/;
@@ -691,6 +689,10 @@ sub _unoverload {
 
     return unless ref $$thing;
     return unless blessed($$thing) || scalar $self->_try(sub{ $$thing->isa('UNIVERSAL') });
+    {
+        local ($!, $@);
+        require overload;
+    }
     my $string_meth = overload::Method( $$thing, $type ) || return;
     $$thing = $$thing->$string_meth();
 }

--- a/lib/Test/Builder/Formatter.pm
+++ b/lib/Test/Builder/Formatter.pm
@@ -4,7 +4,7 @@ use warnings;
 
 our $VERSION = '1.302018';
 
-use base 'Test2::Formatter::TAP';
+BEGIN { require Test2::Formatter::TAP; our @ISA = qw(Test2::Formatter::TAP) }
 
 use Test2::Util::HashBase qw/no_header no_diag/;
 

--- a/lib/Test/Builder/Module.pm
+++ b/lib/Test/Builder/Module.pm
@@ -89,7 +89,8 @@ sub import {
 
     $test->plan(@_);
 
-    $class->export_to_level( 1, $class, @imports );
+    @_ = ($class, @imports);
+    goto &Exporter::import;
 }
 
 sub _strip_imports {

--- a/lib/Test/Builder/Module.pm
+++ b/lib/Test/Builder/Module.pm
@@ -2,7 +2,7 @@ package Test::Builder::Module;
 
 use strict;
 
-use Test::Builder 1.00;
+use Test::Builder;
 
 require Exporter;
 our @ISA = qw(Exporter);

--- a/lib/Test/Builder/Tester.pm
+++ b/lib/Test/Builder/Tester.pm
@@ -3,7 +3,7 @@ package Test::Builder::Tester;
 use strict;
 our $VERSION = '1.302018';
 
-use Test::Builder 0.99;
+use Test::Builder;
 use Symbol;
 use Carp;
 

--- a/lib/Test/Builder/TodoDiag.pm
+++ b/lib/Test/Builder/TodoDiag.pm
@@ -4,7 +4,7 @@ use warnings;
 
 our $VERSION = '1.302018';
 
-use base 'Test2::Event::Diag';
+BEGIN { require Test2::Event::Diag; our @ISA = qw(Test2::Event::Diag) }
 
 sub diagnostics { 0 }
 

--- a/lib/Test/More.pm
+++ b/lib/Test/More.pm
@@ -175,11 +175,21 @@ sub import_extra {
 
     my @other = ();
     my $idx   = 0;
+    my $import;
     while( $idx <= $#{$list} ) {
         my $item = $list->[$idx];
 
         if( defined $item and $item eq 'no_diag' ) {
             $class->builder->no_diag(1);
+        }
+        elsif( defined $item and $item eq 'import' ) {
+            if ($import) {
+                push @$import, @{$list->[ ++$idx ]};
+            }
+            else {
+                $import = $list->[ ++$idx ];
+                push @other, $item, $import;
+            }
         }
         else {
             push @other, $item;
@@ -189,6 +199,18 @@ sub import_extra {
     }
 
     @$list = @other;
+
+    if ($class eq __PACKAGE__ && (!$import || grep $_ eq '$TODO', @$import)) {
+        my $to = $class->builder->exported_to;
+        no strict 'refs';
+        *{"$to\::TODO"} = \our $TODO;
+        if ($import) {
+            @$import = grep $_ ne '$TODO', @$import;
+        }
+        else {
+            push @$list, import => [grep $_ ne '$TODO', @EXPORT];
+        }
+    }
 
     return;
 }

--- a/lib/Test/More.pm
+++ b/lib/Test/More.pm
@@ -19,7 +19,7 @@ sub _carp {
 
 our $VERSION = '1.302018';
 
-use Test::Builder::Module 0.99;
+use Test::Builder::Module;
 our @ISA    = qw(Test::Builder::Module);
 our @EXPORT = qw(ok use_ok require_ok
   is isnt like unlike is_deeply

--- a/lib/Test/Simple.pm
+++ b/lib/Test/Simple.pm
@@ -6,7 +6,7 @@ use strict;
 
 our $VERSION = '1.302018';
 
-use Test::Builder::Module 0.99;
+use Test::Builder::Module;
 our @ISA    = qw(Test::Builder::Module);
 our @EXPORT = qw(ok);
 

--- a/lib/Test2/API.pm
+++ b/lib/Test2/API.pm
@@ -101,25 +101,6 @@ our @EXPORT_OK = qw{
 };
 BEGIN { require Exporter; our @ISA = qw(Exporter) }
 
-# There is a use-cycle between API and API/Context. Context needs to use some
-# API functions as the package is compiling. Test2::API::context() needs
-# Test2::API::Context to be loaded, but we cannot 'require' the module there as
-# it causes a very noticeable performance impact with how often context() is
-# called.
-#
-# This will make sure that Context.pm is loaded the first time this module is
-# imported, then the regular import method is swapped into place.
-sub import {
-    require Test2::API::Context unless $INC{'Test2/API/Context.pm'};
-
-    {
-        no warnings 'redefine';
-        *import = \&Exporter::import;
-    }
-
-    goto &import;
-}
-
 my $STACK       = $INST->stack;
 my $CONTEXTS    = $INST->contexts;
 my $INIT_CBS    = $INST->context_init_callbacks;
@@ -518,6 +499,13 @@ sub run_subtest {
     $ctx->release;
     return $pass;
 }
+
+# There is a use-cycle between API and API/Context. Context needs to use some
+# API functions as the package is compiling. Test2::API::context() needs
+# Test2::API::Context to be loaded, but we cannot 'require' the module there as
+# it causes a very noticeable performance impact with how often context() is
+# called.
+require Test2::API::Context;
 
 1;
 

--- a/lib/Test2/API.pm
+++ b/lib/Test2/API.pm
@@ -99,7 +99,7 @@ our @EXPORT_OK = qw{
     test2_formatter_add
     test2_formatter_set
 };
-use base 'Exporter';
+BEGIN { require Exporter; our @ISA = qw(Exporter) }
 
 # There is a use-cycle between API and API/Context. Context needs to use some
 # API functions as the package is compiling. Test2::API::context() needs

--- a/lib/Test2/API/Breakage.pm
+++ b/lib/Test2/API/Breakage.pm
@@ -12,7 +12,7 @@ our @EXPORT_OK = qw{
     upgrade_required
     known_broken
 };
-use base 'Exporter';
+BEGIN { require Exporter; our @ISA = qw(Exporter) }
 
 sub upgrade_suggested {
     return (

--- a/lib/Test2/API/Instance.pm
+++ b/lib/Test2/API/Instance.pm
@@ -346,14 +346,16 @@ sub disable_ipc_polling {
 sub _ipc_wait {
     my $fail = 0;
 
-    while (CAN_FORK) {
-        my $pid = CORE::wait();
-        my $err = $?;
-        last if $pid == -1;
-        next unless $err;
-        $fail++;
-        $err = $err >> 8;
-        warn "Process $pid did not exit cleanly (status: $err)\n";
+    if (CAN_FORK) {
+        while (1) {
+            my $pid = CORE::wait();
+            my $err = $?;
+            last if $pid == -1;
+            next unless $err;
+            $fail++;
+            $err = $err >> 8;
+            warn "Process $pid did not exit cleanly (status: $err)\n";
+        }
     }
 
     if (USE_THREADS) {

--- a/lib/Test2/Event/Bail.pm
+++ b/lib/Test2/Event/Bail.pm
@@ -5,7 +5,7 @@ use warnings;
 our $VERSION = '1.302018';
 
 
-use base 'Test2::Event';
+BEGIN { require Test2::Event; our @ISA = qw(Test2::Event) }
 use Test2::Util::HashBase qw{reason};
 
 sub callback {

--- a/lib/Test2/Event/Diag.pm
+++ b/lib/Test2/Event/Diag.pm
@@ -5,7 +5,7 @@ use warnings;
 our $VERSION = '1.302018';
 
 
-use base 'Test2::Event';
+BEGIN { require Test2::Event; our @ISA = qw(Test2::Event) }
 use Test2::Util::HashBase qw/message/;
 
 sub init {

--- a/lib/Test2/Event/Exception.pm
+++ b/lib/Test2/Event/Exception.pm
@@ -5,7 +5,7 @@ use warnings;
 our $VERSION = '1.302018';
 
 
-use base 'Test2::Event';
+BEGIN { require Test2::Event; our @ISA = qw(Test2::Event) }
 use Test2::Util::HashBase qw{error};
 
 sub causes_fail { 1 }

--- a/lib/Test2/Event/Note.pm
+++ b/lib/Test2/Event/Note.pm
@@ -5,7 +5,7 @@ use warnings;
 our $VERSION = '1.302018';
 
 
-use base 'Test2::Event';
+BEGIN { require Test2::Event; our @ISA = qw(Test2::Event) }
 use Test2::Util::HashBase qw/message/;
 
 sub init {

--- a/lib/Test2/Event/Ok.pm
+++ b/lib/Test2/Event/Ok.pm
@@ -5,7 +5,7 @@ use warnings;
 our $VERSION = '1.302018';
 
 
-use base 'Test2::Event';
+BEGIN { require Test2::Event; our @ISA = qw(Test2::Event) }
 use Test2::Util::HashBase qw{
     pass effective_pass name todo
 };

--- a/lib/Test2/Event/Plan.pm
+++ b/lib/Test2/Event/Plan.pm
@@ -5,7 +5,7 @@ use warnings;
 our $VERSION = '1.302018';
 
 
-use base 'Test2::Event';
+BEGIN { require Test2::Event; our @ISA = qw(Test2::Event) }
 use Test2::Util::HashBase qw{max directive reason};
 
 use Carp qw/confess/;

--- a/lib/Test2/Event/Skip.pm
+++ b/lib/Test2/Event/Skip.pm
@@ -5,7 +5,7 @@ use warnings;
 our $VERSION = '1.302018';
 
 
-use base 'Test2::Event::Ok';
+BEGIN { require Test2::Event::Ok; our @ISA = qw(Test2::Event::Ok) }
 use Test2::Util::HashBase qw{reason};
 
 sub init {

--- a/lib/Test2/Event/Subtest.pm
+++ b/lib/Test2/Event/Subtest.pm
@@ -5,7 +5,7 @@ use warnings;
 our $VERSION = '1.302018';
 
 
-use base 'Test2::Event::Ok';
+BEGIN { require Test2::Event::Ok; our @ISA = qw(Test2::Event::Ok) }
 use Test2::Util::HashBase qw{subevents buffered subtest_id};
 
 sub init {

--- a/lib/Test2/Event/Waiting.pm
+++ b/lib/Test2/Event/Waiting.pm
@@ -5,7 +5,7 @@ use warnings;
 our $VERSION = '1.302018';
 
 
-use base 'Test2::Event';
+BEGIN { require Test2::Event; our @ISA = qw(Test2::Event) }
 
 sub global { 1 };
 

--- a/lib/Test2/Formatter/TAP.pm
+++ b/lib/Test2/Formatter/TAP.pm
@@ -14,7 +14,7 @@ sub OUT_ERR() { 1 }
 
 use Carp qw/croak/;
 
-use base 'Test2::Formatter';
+BEGIN { require Test2::Formatter; our @ISA = qw(Test2::Formatter) }
 
 my %CONVERTERS = (
     'Test2::Event::Ok'        => 'event_ok',

--- a/lib/Test2/Hub/Interceptor.pm
+++ b/lib/Test2/Hub/Interceptor.pm
@@ -7,7 +7,7 @@ our $VERSION = '1.302018';
 
 use Test2::Hub::Interceptor::Terminator();
 
-use base 'Test2::Hub';
+BEGIN { require Test2::Hub; our @ISA = qw(Test2::Hub) }
 use Test2::Util::HashBase;
 
 sub inherit {

--- a/lib/Test2/Hub/Subtest.pm
+++ b/lib/Test2/Hub/Subtest.pm
@@ -5,7 +5,7 @@ use warnings;
 our $VERSION = '1.302018';
 
 
-use base 'Test2::Hub';
+BEGIN { require Test2::Hub; our @ISA = qw(Test2::Hub) }
 use Test2::Util::HashBase qw/nested bailed_out exit_code manual_skip_all id/;
 use Test2::Util qw/get_tid/;
 

--- a/lib/Test2/IPC.pm
+++ b/lib/Test2/IPC.pm
@@ -19,7 +19,7 @@ use Test2::API qw{
 use Carp qw/confess/;
 
 our @EXPORT_OK = qw/cull/;
-use base 'Exporter';
+BEGIN { require Exporter; our @ISA = qw(Exporter) }
 
 sub import {
     goto &Exporter::import unless test2_init_done();

--- a/lib/Test2/IPC/Driver/Files.pm
+++ b/lib/Test2/IPC/Driver/Files.pm
@@ -5,7 +5,7 @@ use warnings;
 our $VERSION = '1.302018';
 
 
-use base 'Test2::IPC::Driver';
+BEGIN { require Test2::IPC::Driver; our @ISA = qw(Test2::IPC::Driver) }
 
 use Test2::Util::HashBase qw{tempdir event_id tid pid globals};
 

--- a/lib/Test2/Util.pm
+++ b/lib/Test2/Util.pm
@@ -19,7 +19,7 @@ our @EXPORT_OK = qw{
 
     IS_WIN32
 };
-use base 'Exporter';
+BEGIN { require Exporter; our @ISA = qw(Exporter) }
 
 BEGIN {
     *IS_WIN32 = ($^O eq 'MSWin32') ? sub() { 1 } : sub() { 0 };

--- a/lib/Test2/Util.pm
+++ b/lib/Test2/Util.pm
@@ -51,9 +51,25 @@ sub _can_fork {
 
 BEGIN {
     no warnings 'once';
-    *CAN_REALLY_FORK = $Config{d_fork} ? sub() { 1 } : sub() { 0 };
     *CAN_THREAD      = _can_thread()   ? sub() { 1 } : sub() { 0 };
-    *CAN_FORK        = _can_fork()     ? sub() { 1 } : sub() { 0 };
+}
+my $can_fork;
+sub CAN_FORK () {
+    return $can_fork
+        if defined $can_fork;
+    $can_fork = !!_can_fork();
+    no warnings 'redefine';
+    *CAN_FORK = $can_fork ? sub() { 1 } : sub() { 0 };
+    $can_fork;
+}
+my $can_really_fork;
+sub CAN_REALLY_FORK () {
+    return $can_really_fork
+        if defined $can_really_fork;
+    $can_really_fork = !!$Config{d_fork};
+    no warnings 'redefine';
+    *CAN_REALLY_FORK = $can_really_fork ? sub() { 1 } : sub() { 0 };
+    $can_really_fork;
 }
 
 sub _manual_try(&;@) {

--- a/lib/Test2/Util/ExternalMeta.pm
+++ b/lib/Test2/Util/ExternalMeta.pm
@@ -10,7 +10,7 @@ use Carp qw/croak/;
 sub META_KEY() { '_meta' }
 
 our @EXPORT = qw/meta set_meta get_meta delete_meta/;
-use base 'Exporter';
+BEGIN { require Exporter; our @ISA = qw(Exporter) }
 
 sub set_meta {
     my $self = shift;

--- a/lib/Test2/Util/HashBase.pm
+++ b/lib/Test2/Util/HashBase.pm
@@ -8,48 +8,37 @@ our $VERSION = '1.302018';
 require Carp;
 $Carp::Internal{+__PACKAGE__} = 1;
 
-my %ATTRS;
-my %META;
+my %ATTR_SUBS;
 
-sub _get_inherited_attrs {
-    no strict 'refs';
-    my @todo = map @{"$_\::ISA"}, @_;
-    my %seen;
-    my @all;
-    while (my $pkg = shift @todo) {
-        next if $seen{$pkg}++;
-        my $found = $META{$pkg};
-        push @all => %$found if $found;
-
-        my $isa = \@{"$pkg\::ISA"};
-        push @todo => @$isa if @$isa;
+BEGIN {
+    # these are not strictly equivalent, but for out use we don't care
+    # about order
+    *_isa = ($] >= 5.010 && require mro) ? \&mro::get_linear_isa : sub {
+        no strict 'refs';
+        my @packages = ($_[0]);
+        my %seen;
+        for my $package (@packages) {
+            push @packages, grep !$seen{$_}++, @{"$package\::ISA"};
+        }
+        return \@packages;
     }
-
-    return \@all;
-}
-
-sub _make_subs {
-    my ($str) = @_;
-    return $ATTRS{$str} ||= {
-        uc($str) => sub() { $str },
-        $str => sub { $_[0]->{$str} },
-        "set_$str" => sub { $_[0]->{$str} = $_[1] },
-    };
 }
 
 sub import {
     my $class = shift;
     my $into = caller;
 
-    my %attrs = map %{_make_subs($_)}, @_;
-
-    my @meta = map uc, @_;
-    @{$META{$into}}{@meta} = map $attrs{$_}, @meta;
-
+    my $isa = _isa($into);
+    my $attr_subs = $ATTR_SUBS{$into} ||= {};
     my %subs = (
-        %attrs,
-        @{_get_inherited_attrs($into)},
-        $into->can('new') ? () : (new => \&_new)
+        ($into->can('new') ? () : (new => \&_new)),
+        (map %{ $ATTR_SUBS{$_}||{} }, @{$isa}[1 .. $#$isa]),
+        (map {
+            my ($sub, $attr) = (uc $_, $_);
+            $sub => ($attr_subs->{$sub} = sub() { $attr }),
+            $attr => sub { $_[0]->{$attr} },
+            "set_$attr" => sub { $_[0]->{$attr} = $_[1] },
+        } @_),
     );
 
     no strict 'refs';


### PR DESCRIPTION
This is a number of micro-optimizations to the code.  These changes are not all well tested yet, but I'm opening this for discussion.

As a rough benchmark, I ran `perl -MTest::More -e'ok 1; done_testing;' 1000 times.  These changes reduced the runtime from 61.3 seconds to 55.9 seconds.

The largest gains are gotten by preventing unneeded modules from being loaded.  Lazy loading overload is trivial (and is what Test::Builder used to do).  Preventing `Config_heavy.pl` from being needed in most cases is also straightforward.

Preventing Exporter::Heavy from being needed is uglier.  In one case, a goto &Exporter::import is used rather than calling export_to_level.  I believe this may be problematic on older perl 5.8 releases.  In another case, it manually handles exporting $TODO, as Exporter::Heavy is needed for any non-sub export.  Applying only one of these two changes would be pointless.