### PR TITLE
Mask signals when writing IPC files

### DIFF
--- a/lib/Test2/IPC/Driver/Files.pm
+++ b/lib/Test2/IPC/Driver/Files.pm
@@ -154,12 +154,11 @@ do so if Test::Builder is loaded for legacy reasons.
 
     my $to_block = POSIX::SigSet->new(
         POSIX::SIGINT(),
-        POSIX::SIGABRT(),
         POSIX::SIGALRM(),
         POSIX::SIGHUP(),
-        POSIX::SIGKILL(),
-        POSIX::SIGQUIT(),
         POSIX::SIGTERM(),
+        POSIX::SIGUSR1(),
+        POSIX::SIGUSR2(),
     );
     my $old = POSIX::SigSet->new;
     my $blocked = POSIX::sigprocmask(POSIX::SIG_BLOCK(), $to_block, $old);
@@ -173,7 +172,7 @@ do so if Test::Builder is loaded for legacy reasons.
     };
 
     # If our block was successful we want to restore the old mask.
-    POSIX::sigprocmask(POSIX::SIG_SETMASK, $old) if defined $blocked;
+    POSIX::sigprocmask(POSIX::SIG_SETMASK(), $old) if defined $blocked;
 
     if (!$ok) {
         my $src_file = __FILE__;

--- a/lib/Test2/IPC/Driver/Files.pm
+++ b/lib/Test2/IPC/Driver/Files.pm
@@ -175,7 +175,7 @@ do so if Test::Builder is loaded for legacy reasons.
     };
 
     # If our block was successful we want to restore the old mask.
-    POSIX::sigprocmask(POSIX::SIG_SETMASK(), $old) if defined $blocked;
+    POSIX::sigprocmask(POSIX::SIG_SETMASK(), $old, POSIX::SigSet->new()) if defined $blocked;
 
     if (!$ok) {
         my $src_file = __FILE__;

--- a/lib/Test2/Util.pm
+++ b/lib/Test2/Util.pm
@@ -16,8 +16,14 @@ our @EXPORT_OK = qw{
     CAN_THREAD
     CAN_REALLY_FORK
     CAN_FORK
+
+    IS_WIN32
 };
 use base 'Exporter';
+
+BEGIN {
+    *IS_WIN32 = $^O eq 'MSWin32' ? sub() { 1 } : sub() { 0 };
+}
 
 sub _can_thread {
     return 0 unless $] >= 5.008001;
@@ -36,7 +42,7 @@ sub _can_thread {
 
 sub _can_fork {
     return 1 if $Config{d_fork};
-    return 0 unless $^O eq 'MSWin32' || $^O eq 'NetWare';
+    return 0 unless IS_WIN32 || $^O eq 'NetWare';
     return 0 unless $Config{useithreads};
     return 0 unless $Config{ccflags} =~ /-DPERL_IMPLICIT_SYS/;
 
@@ -80,7 +86,7 @@ sub _local_try(&;@) {
 # before forking or starting a new thread. So for those systems we use the
 # non-local form. When possible though we use the faster 'local' form.
 BEGIN {
-    if ($^O eq 'MSWin32' && $] < 5.020002) {
+    if (IS_WIN32 && $] < 5.020002) {
         *try = \&_manual_try;
     }
     else {

--- a/t/Test2/modules/Util.t
+++ b/t/Test2/modules/Util.t
@@ -12,6 +12,8 @@ use Test2::Util qw/
     CAN_FORK
     CAN_THREAD
     CAN_REALLY_FORK
+
+    IS_WIN32
 /;
 
 {
@@ -33,5 +35,8 @@ is(pkg_to_file('A::Package::Name'), 'A/Package/Name.pm', "Converted package to f
 CAN_THREAD();
 CAN_FORK();
 CAN_REALLY_FORK();
+IS_WIN32();
+
+is(IS_WIN32(), ($^O eq 'Win32' ? 1 : 0), "IS_WIN32 is correct ($^O)");
 
 done_testing;


### PR DESCRIPTION
This *appears* to fix the Test::TCP issues. I am not sure of a good way to test this change.