### PR TITLE
Delay setting PID/TID

### DIFF
--- a/lib/Test2/API/Instance.pm
+++ b/lib/Test2/API/Instance.pm
@@ -15,7 +15,7 @@ use Test2::Util::Trace();
 use Test2::API::Stack();
 
 use Test2::Util::HashBase qw{
-    pid tid
+    _pid _tid
     no_wait
     finalized loaded
     ipc stack formatter
@@ -34,6 +34,9 @@ use Test2::Util::HashBase qw{
     context_init_callbacks
     context_release_callbacks
 };
+
+sub pid { $_[0]->{+_PID} ||= $$ }
+sub tid { $_[0]->{+_TID} ||= get_tid() }
 
 # Wrap around the getters that should call _finalize.
 BEGIN {
@@ -63,8 +66,8 @@ sub init { $_[0]->reset }
 sub reset {
     my $self = shift;
 
-    delete $self->{+PID};
-    delete $self->{+TID};
+    delete $self->{+_PID};
+    delete $self->{+_TID};
 
     $self->{+CONTEXTS}    = {};
 
@@ -96,8 +99,8 @@ sub _finalize {
 
     $self->{+FINALIZED} = $caller;
 
-    $self->{+PID} ||= $$;
-    $self->{+TID} ||= get_tid();
+    $self->{+_PID} = $$        unless defined $self->{+_PID};
+    $self->{+_TID} = get_tid() unless defined $self->{+_TID};
 
     unless ($self->{+FORMATTER}) {
         my ($formatter, $source);
@@ -224,8 +227,8 @@ sub add_post_load_callback {
 sub load {
     my $self = shift;
     unless ($self->{+LOADED}) {
-        $self->{+PID} ||= $$;
-        $self->{+TID} ||= get_tid();
+        $self->{+_PID} = $$        unless defined $self->{+_PID};
+        $self->{+_TID} = get_tid() unless defined $self->{+_TID};
 
         # This is for https://github.com/Test-More/test-more/issues/16
         # and https://rt.perl.org/Public/Bug/Display.html?id=127774
@@ -384,8 +387,8 @@ sub _ipc_wait {
 sub DESTROY {
     my $self = shift;
 
-    return unless defined($self->{+PID}) && $self->{+PID} == $$;
-    return unless defined($self->{+TID}) && $self->{+TID} == get_tid();
+    return unless defined($self->{+_PID}) && $self->{+_PID} == $$;
+    return unless defined($self->{+_TID}) && $self->{+_TID} == get_tid();
 
     shmctl($self->{+IPC_SHM_ID}, IPC::SysV::IPC_RMID(), 0)
         if defined $self->{+IPC_SHM_ID};
@@ -436,7 +439,7 @@ This is not a supported configuration, you will have problems.
         $new_exit = 255;
     }
 
-    if (!defined($self->{+PID}) or !defined($self->{+TID}) or $self->{+PID} != $$ or $self->{+TID} != get_tid()) {
+    if (!defined($self->{+_PID}) or !defined($self->{+_TID}) or $self->{+_PID} != $$ or $self->{+_TID} != get_tid()) {
         $? = $exit;
         return;
     }

--- a/lib/Test2/IPC.pm
+++ b/lib/Test2/IPC.pm
@@ -24,8 +24,8 @@ use base 'Exporter';
 sub import {
     goto &Exporter::import unless test2_init_done();
 
-    confess "Cannot add IPC in a child process" if test2_pid() != $$;
-    confess "Cannot add IPC in a child thread"  if test2_tid() != get_tid();
+    confess "Cannot add IPC in a child process (" . test2_pid() . " vs $$)" if test2_pid() != $$;
+    confess "Cannot add IPC in a child thread (" . test2_tid() . " vs " . get_tid() . ")"  if test2_tid() != get_tid();
 
     Test2::API::_set_ipc(_make_ipc());
     apply_ipc(test2_stack());

--- a/t/Test2/modules/API/Instance.t
+++ b/t/Test2/modules/API/Instance.t
@@ -197,7 +197,7 @@ if (CAN_THREAD && $] ge '5.010') {
 
 {
     $one->reset();
-    $one->set_tid(1);
+    $one->set__tid(1);
     local $? = 0;
     $one->set_exit;
     is($?, 0, "no errors on exit");

--- a/t/Test2/modules/API/Instance.t
+++ b/t/Test2/modules/API/Instance.t
@@ -11,8 +11,6 @@ my $one = $CLASS->new;
 is_deeply(
     $one,
     {
-        pid      => $$,
-        tid      => get_tid(),
         contexts => {},
 
         finalized => undef,
@@ -45,8 +43,6 @@ $one->reset;
 is_deeply(
     $one,
     {
-        pid      => $$,
-        tid      => get_tid(),
         contexts => {},
 
         ipc_polling => undef,
@@ -226,6 +222,7 @@ if (CAN_THREAD && $] ge '5.010') {
 
 {
     $one->reset();
+    $one->load();
     $one->stack->top->set_failed(2);
     local $? = 0;
     $one->set_exit;
@@ -234,6 +231,7 @@ if (CAN_THREAD && $] ge '5.010') {
 
 {
     $one->reset();
+    $one->load();
     local $? = 500;
     $one->set_exit;
     is($?, 255, "set exit code to a sane number");
@@ -243,6 +241,7 @@ if (CAN_THREAD && $] ge '5.010') {
     local %INC = %INC;
     delete $INC{'Test2/IPC.pm'};
     $one->reset();
+    $one->load();
     my @events;
     $one->stack->top->filter(sub { push @events => $_[1]; undef});
     $one->stack->new_hub;
@@ -287,6 +286,7 @@ This is not a supported configuration, you will have problems.
     local *Test2::API::Breakage::report = sub { $ran++; return "foo" };
     use warnings qw/redefine once/;
     $one->reset();
+    $one->load();
 
     my $stderr = "";
     {
@@ -308,6 +308,7 @@ foo
 
 {
     $one->reset();
+    $one->load();
     my @events;
     $one->stack->top->filter(sub { push @events => $_[1]; undef});
     $one->stack->new_hub;


### PR DESCRIPTION
This makes it possible for preloading harnesses like forkprove and
Test2::Harness to preload Test::Builder.