### PR TITLE
Fix IPC files being leftover

### DIFF
--- a/lib/Test2/IPC/Driver/Files.pm
+++ b/lib/Test2/IPC/Driver/Files.pm
@@ -7,7 +7,7 @@ our $VERSION = '1.302018';
 
 use base 'Test2::IPC::Driver';
 
-use Test2::Util::HashBase qw{tempdir event_id tid pid globals};
+use Test2::Util::HashBase qw{tempdir event_id tid pid globals _cleanup};
 
 use Scalar::Util qw/blessed/;
 use File::Temp();
@@ -45,6 +45,8 @@ sub init {
     $self->{+PID} = $$;
 
     $self->{+GLOBALS} = {};
+
+    $self->{+_CLEANUP} = 0;
 
     return $self;
 }
@@ -285,8 +287,12 @@ sub waiting {
     return;
 }
 
-sub DESTROY {
+sub DESTROY { $_[0]->cleanup }
+
+sub cleanup {
     my $self = shift;
+
+    return if $self->{+_CLEANUP}++;
 
     return unless defined $self->pid;
     return unless defined $self->tid;

--- a/lib/Test2/Util.pm
+++ b/lib/Test2/Util.pm
@@ -17,6 +17,8 @@ our @EXPORT_OK = qw{
     CAN_REALLY_FORK
     CAN_FORK
 
+    have_detached_threads
+
     IS_WIN32
 };
 use base 'Exporter';
@@ -96,22 +98,52 @@ BEGIN {
 
 BEGIN {
     if (CAN_THREAD) {
+        my @detached;
+        # the 0 + is to prevent it from trying to make it a constant and
+        # warning us that it might be modified in another place.
+        *have_detached_threads = sub() { @detached };
+
+        my $mpatch = 0;
+        my $do_patch = sub {
+            $mpatch++;
+            my $orig = threads->can('detach');
+            no warnings qw/once redefine/;
+            *threads::detach = sub {
+                push @detached => $_[0];
+                goto &$orig;
+            }
+        };
+
         if ($INC{'threads.pm'}) {
             # Threads are already loaded, so we do not need to check if they
             # are loaded each time
             *USE_THREADS = sub() { 1 };
             *get_tid     = sub() { threads->tid() };
+
+            $do_patch->();
         }
         else {
             # :-( Need to check each time to see if they have been loaded.
-            *USE_THREADS = sub() { $INC{'threads.pm'} ? 1 : 0 };
-            *get_tid     = sub() { $INC{'threads.pm'} ? threads->tid() : 0 };
+            *USE_THREADS = sub() {
+                return 0 unless $INC{'threads.pm'};
+                return 1 if $mpatch;
+                $do_patch->();
+                return 1;
+            };
+
+            *get_tid = sub() {
+                return 0 unless $INC{'threads.pm'};
+                return threads->tid() if $mpatch;
+                $do_patch->();
+                return threads->tid();
+            };
         }
     }
     else {
         # No threads, not now, not ever!
         *USE_THREADS = sub() { 0 };
         *get_tid     = sub() { 0 };
+        *have_detached_threads = sub() { () };
     }
 }
 

--- a/t/regression/673-leftover_files.t
+++ b/t/regression/673-leftover_files.t
@@ -1,0 +1,34 @@
+use strict;
+use warnings;
+
+use Test2::Util qw/CAN_THREAD/;
+BEGIN {
+    unless(CAN_THREAD) {
+        require Test::More;
+        Test::More->import(skip_all => "threads are not supported");
+    }
+}
+
+use threads;
+
+open(my $stderr, '>&', STDERR) or die "could not clone STDERR";
+my $tmpdir;
+END {
+    return unless -d $tmpdir;
+
+    print $stderr "The temporary directory '$tmpdir' was not cleaned up, setting exit value to 255.\n";
+
+    $? = 255;
+    exit 255;
+}
+use Test::More tests => 2;
+
+ok(1);
+$tmpdir = Test2::API::test2_ipc()->tempdir;
+
+threads->create(sub { while (1) { sleep 1 } })->detach;
+
+ok(1);
+
+close(STDERR);
+open(STDERR, '>&', STDOUT);


### PR DESCRIPTION
 * Cleanup a test that left them behind.
 * Detect detached threads that will block global destruction