### PR TITLE
use ExportLevel rather than goto when calling Exporter

### DIFF
--- a/lib/Test/Builder/Module.pm
+++ b/lib/Test/Builder/Module.pm
@@ -89,8 +89,8 @@ sub import {
 
     $test->plan(@_);
 
-    @_ = ($class, @imports);
-    goto &Exporter::import;
+    local $Exporter::ExportLevel = $Exporter::ExportLevel + 1;
+    $class->Exporter::import(@imports);
 }
 
 sub _strip_imports {


### PR DESCRIPTION
On perl 5.8.4, modifying @_ and then using goto will cause segfaults
later in the program.  Exporter has an ExportLevel variable that we can
use to export to the correct location and avoid the goto.