### PR TITLE
Filename portability for Test2.

### DIFF
--- a/lib/Test2/IPC/Driver/Files.pm
+++ b/lib/Test2/IPC/Driver/Files.pm
@@ -53,7 +53,7 @@ sub hub_file {
     my $self = shift;
     my ($hid) = @_;
     my $tdir = $self->{+TEMPDIR};
-    return File::Spec->canonpath("$tdir/HUB-$hid");
+    return File::Spec->catfile($tdir, "HUB-$hid");
 }
 
 sub event_file {
@@ -69,7 +69,7 @@ sub event_file {
     my @type = split '::', $type;
     my $name = join('-', $hid, $$, get_tid(), $self->{+EVENT_ID}++, @type);
 
-    return File::Spec->canonpath("$tempdir/$name");
+    return File::Spec->catfile($tempdir, $name);
 }
 
 sub add_hub {
@@ -228,7 +228,7 @@ sub cull {
         next if $global && $self->{+GLOBALS}->{$hid}->{$file}++;
 
         # Untaint the path.
-        my $full = File::Spec->canonpath("$tempdir/$file");
+        my $full = File::Spec->catfile($tempdir, $file);
         ($full) = ($full =~ m/^(.*)$/gs);
 
         my $obj = $self->read_event_file($full);
@@ -300,7 +300,7 @@ sub DESTROY {
     while(my $file = readdir($dh)) {
         next if $file =~ m/^\.+$/;
         next if $file =~ m/\.complete$/;
-        my $full = File::Spec->canonpath("$tempdir/$file");
+        my $full = File::Spec->catfile($tempdir, $file);
 
         if ($file =~ m/^(GLOBAL|HUB-)/) {
             $full =~ m/^(.*)$/;

--- a/t/Test2/modules/IPC/Driver/Files.t
+++ b/t/Test2/modules/IPC/Driver/Files.t
@@ -1,6 +1,7 @@
 BEGIN { require "t/tools.pl" };
 use Test2::Util qw/get_tid USE_THREADS try/;
 use File::Temp qw/tempfile/;
+use File::Spec qw/catfile/;
 use strict;
 use warnings;
 
@@ -42,8 +43,9 @@ is($ipc->tid, get_tid(), "stored the tid");
 my $hid = '12345';
 
 $ipc->add_hub($hid);
-ok(-f $ipc->tempdir . '/HUB-' . $hid, "wrote hub file");
-if(ok(open(my $fh, '<', $ipc->tempdir . '/HUB-' . $hid), "opened hub file")) {
+my $hubfile = File::Spec->catfile($ipc->tempdir, "HUB-$hid");
+ok(-f $hubfile, "wrote hub file");
+if(ok(open(my $fh, '<', $hubfile), "opened hub file")) {
     my @lines = <$fh>;
     close($fh);
     is_deeply(
@@ -62,7 +64,7 @@ $ipc->send($hid, bless({ foo => 1 }, 'Foo'));
 $ipc->send($hid, bless({ bar => 1 }, 'Foo'));
 
 opendir(my $dh, $ipc->tempdir) || die "Could not open tempdir: !?";
-my @files = grep { $_ !~ m/^\.+$/ && $_ ne "HUB-$hid" } readdir($dh);
+my @files = grep { $_ !~ m/^\.+$/ && $_ !~ m/^HUB-$hid/ } readdir($dh);
 closedir($dh);
 is(@files, 2, "2 files added to the IPC directory");
 
@@ -74,7 +76,7 @@ is_deeply(
 );
 
 opendir($dh, $ipc->tempdir) || die "Could not open tempdir: !?";
-@files = grep { $_ !~ m/^\.+$/ && $_ ne "HUB-$hid" } readdir($dh);
+@files = grep { $_ !~ m/^\.+$/ && $_ !~ m/^HUB-$hid/ } readdir($dh);
 closedir($dh);
 is(@files, 0, "All files collected");
 


### PR DESCRIPTION
Explicitly concatenating paths with a forward slash doesn't work
so well on filesystems that don't use slashes as separators. So
use catfile instead.

Also, on VMS, all files have an extension and a zero-length
extension is returned as a '.' from readdir(), so only match
the start of the extension-less hub files when testing for them.