### PR TITLE
Remove accessors=>[] in Test2::Formatter::TAP pod

### DIFF
--- a/lib/Test2/Formatter/TAP.pm
+++ b/lib/Test2/Formatter/TAP.pm
@@ -381,7 +381,7 @@ order to do this you use the C<register_event()> class method.
     use Test2::Formatter::TAP;
 
     use base 'Test2::Event';
-    use Test2::Util::HashBase accessors => qw/pass name diag note/;
+    use Test2::Util::HashBase qw/pass name diag note/;
 
     Test2::Formatter::TAP->register_event(
         __PACKAGE__,

--- a/lib/Test2/Formatter/TAP.pm
+++ b/lib/Test2/Formatter/TAP.pm
@@ -381,7 +381,7 @@ order to do this you use the C<register_event()> class method.
     use Test2::Formatter::TAP;
 
     use base 'Test2::Event';
-    use Test2::Util::HashBase accessors => [qw/pass name diag note/];
+    use Test2::Util::HashBase accessors => qw/pass name diag note/;
 
     Test2::Formatter::TAP->register_event(
         __PACKAGE__,


### PR DESCRIPTION
Test2::Util::HashBase just takes a plain list.

You won’t believe how I found this. :-)

I was running Porting/leakfinder.pl in the perl repository.  It executes every line in every file in a loop and checks whether the number of SVs goes up.  So it took this line from the documentation and reported it as a leak.

It was ‘leaking’ because it was creating constants with names like ARRAY(0X7F9C5982A698) (and one named ACCESSORS, too), so they wouldn’t overwrite the previous constants upon multiple ‘use Test2::Util::HashBase’ invocations.