### PR TITLE
Declare breakage of Test::UseAllModules >= 0.12, <= 0.14 (#685)

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -50,6 +50,7 @@ Test::More::Prefix             = <= 0.005
 Test::ParallelSubtest          = <= 0.05
 Test::Pretty                   = <= 0.32
 Test::SharedFork               = <= 0.34
+Test::UseAllModules            = >= 0.12, <= 0.14
 Test::Wrapper                  = <= 0.3.0
 ; These have tests that will not pass on old versions, but do not break if
 ; already installed, no need to notify.

--- a/lib/Test2/API/Breakage.pm
+++ b/lib/Test2/API/Breakage.pm
@@ -30,6 +30,7 @@ sub upgrade_required {
         'Test::Modern'            => '0.012',
         'Test::SharedFork'        => '0.34',
         'Test::Alien'             => '0.04',
+        'Test::UseAllModules'     => '0.14',
 
         'Test::Clustericious::Cluster' => '0.30',
     );

--- a/lib/Test2/Transition.pod
+++ b/lib/Test2/Transition.pod
@@ -248,6 +248,14 @@ tool.
 
 Fixed in version: 0.012
 
+=item Test::UseAllModules
+
+Version 0.14 relied on C<< Test::Builder->history >> which was available in
+Test::Builder 1.5. Versions 0.12 and 0.13 relied on other Test::Builder
+internals.
+
+Fixed in version: 0.15
+
 =back
 
 =head2 STILL BROKEN


### PR DESCRIPTION
Fixes #685.