### PR TITLE
fix doc in Test2::API::Context

### DIFF
--- a/lib/Test2/API/Context.pm
+++ b/lib/Test2/API/Context.pm
@@ -412,7 +412,7 @@ inherit it:
 =item you MUST always use the context() sub from Test2::API
 
 Creating your own context via C<< Test2::API::Context->new() >> will almost never
-produce a desirable result. Use C<context()> which is exported by L<Test2>.
+produce a desirable result. Use C<context()> which is exported by L<Test2::API>.
 
 There are a handful of cases where a tool author may want to create a new
 context by hand, which is why the C<new> method exists. Unless you really know


### PR DESCRIPTION
Fixed document.
change from 'Test2' to 'Test2::API'