### PR TITLE
fix failing contxt( hub => $hub )

### DIFF
--- a/lib/Test2/API.pm
+++ b/lib/Test2/API.pm
@@ -217,7 +217,7 @@ sub context {
         unless defined wantarray;
 
     my $stack   = $params{stack} || $STACK;
-    my $hub     = $params{hub}   || @$stack ? $stack->[-1] : $stack->top;
+    my $hub     = $params{hub}   || (@$stack ? $stack->[-1] : $stack->top);
     my $hid     = $hub->{hid};
     my $current = $CONTEXTS->{$hid};
 

--- a/t/Test2/modules/API.t
+++ b/t/Test2/modules/API.t
@@ -236,6 +236,14 @@ sub {
 }->();
 
 
+sub {
+    my $hub = Test2::Hub->new();
+    my $ctx = context(hub => $hub);
+    is($ctx->hub,$hub, 'got the hub of context() argument');
+    $ctx->release;
+}->();
+
+
 my $sub = sub { };
 
 Test2::API::test2_add_callback_context_acquire($sub);


### PR DESCRIPTION
`` my $hub     = $params{hub}   || @$stack ? $stack->[-1] : $stack->top;``
 is
``my $hub     = (  $params{hub}   || @$stack  ) ? $stack->[-1] : $stack->top;``

Probably it is correct below
`` my $hub     = $params{hub}   || (@$stack ? $stack->[-1] : $stack->top)``


By the way,  
``(@$stack ? $stack->[-1] : $stack->top)``  and ``$stack->top``  are the same effect.
Is this reason a performance?
