### PR TITLE
Fix edge case discussed in #711 (escape trailing slash)

### DIFF
--- a/lib/Test2/Formatter/TAP.pm
+++ b/lib/Test2/Formatter/TAP.pm
@@ -159,7 +159,7 @@ sub event_ok {
     my @extra;
     defined($name) && (
         (index($name, "\n") != -1 && (($name, @extra) = split(/\n\r?/, $name, -1))),
-        (index($name, "#" ) != -1 && (($name =~ s|\\|\\\\|g), ($name =~ s|#|\\#|g)))
+        ((index($name, "#" ) != -1  || substr($name, -1) eq '\\') && (($name =~ s|\\|\\\\|g), ($name =~ s|#|\\#|g)))
     );
 
     my $space = @extra ? ' ' x (length($out) + 2) : '';

--- a/t/Test2/modules/Formatter/TAP.t
+++ b/t/Test2/modules/Formatter/TAP.t
@@ -253,6 +253,22 @@ tests special_characters => sub {
         ],
         "Escape # and any slashes already present, and split newlines, do not escape the newlines"
     );
+
+    $ok = Test2::Event::Ok->new(
+        trace => $trace,
+        name  => "Nothing special until the end \\\nfoo \\ bar",
+        pass  => 1,
+    );
+
+    is_deeply(
+        [$fmt->event_tap($ok, 1)],
+        [
+            [OUT_STD, "ok 1 - Nothing special until the end \\\\\n"],
+            [OUT_STD, "#      foo \\ bar\n"],
+        ],
+        "Special case, escape things if last character of the first line is a \\"
+    );
+
 };
 
 for my $pass (1, 0) {


### PR DESCRIPTION
I closed #711, but one edge case was discussed after that.

Test::Harness would have problems with a test name ending with an
unescaped '\' character. This special cases that condition and escapes
it.