### PR TITLE
use null output rather than throwaway scalar to silence STDOUT/STDERR

### DIFF
--- a/t/00-report.t
+++ b/t/00-report.t
@@ -4,8 +4,9 @@ use warnings;
 my $exit = 0;
 END{ $? = $exit }
 
+use File::Spec;
+
 my ($stderr, $stdout);
-my $fake = "";
 BEGIN {
     $exit = 0;
     END{ $? = $exit }
@@ -22,8 +23,8 @@ BEGIN {
         exit $exit;
     }
 
-    open(STDOUT, '>>', \$fake);
-    open(STDERR, '>>', \$fake);
+    open(STDOUT, '>', File::Spec->devnull);
+    open(STDERR, '>', File::Spec->devnull);
 }
 
 use Test2::Util qw/CAN_FORK CAN_REALLY_FORK CAN_THREAD/;


### PR DESCRIPTION
Having both STDOUT and STDERR opened to the same scalar causes issues
on some 5.8.9 threaded builds.  Avoid this by opening them to null
output rather than a throwaway scalar.  This also means they are backed
by a real OS level filehandle rather than only working on the PerlIO
layer.