### PR TITLE
add color support for 'MSWin32' platforms

### DIFF
--- a/lib/Test/Builder/Tester.pm
+++ b/lib/Test/Builder/Tester.pm
@@ -450,7 +450,8 @@ tests than we strictly should have and it'll register any failures we
 had that we were testing for as real failures.
 
 The color function doesn't work unless L<Term::ANSIColor> is
-compatible with your terminal.
+compatible with your terminal. Additionally, L<Win32::Console::ANSI>
+must be installed on windows platforms for color output.
 
 Bugs (and requests for new features) can be reported to the author
 though the CPAN RT system:
@@ -560,6 +561,8 @@ sub complaint {
         # get color
         eval { require Term::ANSIColor };
         unless($@) {
+            eval { require Win32::Console::ANSI } if 'MSWin32' eq $^O;  # support color on windows platforms
+
             # colours
 
             my $green = Term::ANSIColor::color("black") . Term::ANSIColor::color("on_green");

--- a/lib/Test/Tester.pm
+++ b/lib/Test/Tester.pm
@@ -42,9 +42,9 @@ my $reset = '';
 
 if (my $want_colour = $ENV{TESTTESTERCOLOUR} || $ENV{TESTTESTERCOLOR})
 {
-	if (eval "require Term::ANSIColor")
+	if (eval { require Term::ANSIColor; 1 })
 	{
-		eval 'require Win32::Console::ANSI' if 'MSWin32' eq $^O;  # support color on windows platforms
+		eval { require Win32::Console::ANSI } if 'MSWin32' eq $^O;  # support color on windows platforms
 		my ($f, $b) = split(",", $want_colour);
 		$colour = Term::ANSIColor::color($f).Term::ANSIColor::color("on_$b");
 		$reset = Term::ANSIColor::color("reset");

--- a/lib/Test/Tester.pm
+++ b/lib/Test/Tester.pm
@@ -44,6 +44,7 @@ if (my $want_colour = $ENV{TESTTESTERCOLOUR} || $ENV{TESTTESTERCOLOR})
 {
 	if (eval "require Term::ANSIColor")
 	{
+		eval 'require Win32::Console::ANSI' if 'MSWin32' eq $^O;  # support color on windows platforms
 		my ($f, $b) = split(",", $want_colour);
 		$colour = Term::ANSIColor::color($f).Term::ANSIColor::color("on_$b");
 		$reset = Term::ANSIColor::color("reset");


### PR DESCRIPTION
This is a simple addition that activates color output on 'MSWin32' platforms.

No other code changes are needed.
