### PR TITLE
Update bug tracker url in docs

### DIFF
--- a/lib/Test/Builder/Tester.pm
+++ b/lib/Test/Builder/Tester.pm
@@ -453,8 +453,8 @@ The color function doesn't work unless L<Term::ANSIColor> is
 compatible with your terminal.
 
 Bugs (and requests for new features) can be reported to the author
-though the CPAN RT system:
-L<http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Test-Builder-Tester>
+though GitHub:
+L<https://github.com/Test-More/test-more/issues>
 
 =head1 AUTHOR
 

--- a/lib/Test/More.pm
+++ b/lib/Test/More.pm
@@ -1976,7 +1976,7 @@ the perl-qa gang.
 
 =head1 BUGS
 
-See F<http://rt.cpan.org> to report and view bugs.
+See F<https://github.com/Test-More/test-more/issues> to report and view bugs.
 
 
 =head1 SOURCE


### PR DESCRIPTION
- Test::More already has it's rt.cpan.org bug tracker disabled, so forward users directly here
- Test::Builder::Tester points to an active rt.cpan.org queue, but it points back to https://metacpan.org/release/Test-Builder-Tester, which is unexpected. Probably, it's better to disable it too?