### PR TITLE
handle the minus on negative pids in forks on windows

### DIFF
--- a/lib/Test2/Hub.pm
+++ b/lib/Test2/Hub.pm
@@ -6,7 +6,7 @@ our $VERSION = '1.302065';
 
 
 use Carp qw/carp croak confess/;
-use Test2::Util qw/get_tid/;
+use Test2::Util qw/get_tid ipc_separator/;
 
 use Scalar::Util qw/weaken/;
 
@@ -39,7 +39,7 @@ sub init {
 
     $self->{+PID} = $$;
     $self->{+TID} = get_tid();
-    $self->{+HID} = join '-', $self->{+PID}, $self->{+TID}, $ID_POSTFIX++;
+    $self->{+HID} = join ipc_separator, $self->{+PID}, $self->{+TID}, $ID_POSTFIX++;
 
     $self->{+COUNT}    = 0;
     $self->{+FAILED}   = 0;

--- a/lib/Test2/IPC/Driver/Files.pm
+++ b/lib/Test2/IPC/Driver/Files.pm
@@ -15,7 +15,7 @@ use Storable();
 use File::Spec();
 use POSIX();
 
-use Test2::Util qw/try get_tid pkg_to_file IS_WIN32/;
+use Test2::Util qw/try get_tid pkg_to_file IS_WIN32 ipc_separator/;
 use Test2::API qw/test2_ipc_set_pending/;
 
 BEGIN {
@@ -72,7 +72,7 @@ sub init {
     my $self = shift;
 
     my $tmpdir = File::Temp::tempdir(
-        $ENV{T2_TEMPDIR_TEMPLATE} || "test2-$$-XXXXXX",
+        $ENV{T2_TEMPDIR_TEMPLATE} || "test2" . ipc_separator . $$ . ipc_separator . "XXXXXX",
         CLEANUP => 0,
         TMPDIR => 1,
     );
@@ -98,7 +98,7 @@ sub hub_file {
     my $self = shift;
     my ($hid) = @_;
     my $tdir = $self->{+TEMPDIR};
-    return File::Spec->catfile($tdir, "HUB-$hid");
+    return File::Spec->catfile($tdir, "HUB" . ipc_separator . $hid);
 }
 
 sub event_file {
@@ -112,7 +112,7 @@ sub event_file {
         unless $type->isa('Test2::Event');
 
     my @type = split '::', $type;
-    my $name = join('-', $hid, $$, get_tid(), $self->{+EVENT_ID}++, @type);
+    my $name = join(ipc_separator, $hid, $$, get_tid(), $self->{+EVENT_ID}++, @type);
 
     return File::Spec->catfile($tempdir, $name);
 }
@@ -296,8 +296,8 @@ sub parse_event_filename {
     my $complete = substr($file, -9, 9) eq '.complete' || 0 and substr($file, -9, 9, "");
     my $ready    = substr($file, -6, 6) eq '.ready'    || 0 and substr($file, -6, 6, "");
 
-    my @parts = split '-', $file;
-    my ($global, $hid) = $parts[0] eq 'GLOBAL' ? (1, shift @parts) : (0, join '-' => splice(@parts, 0, 3));
+    my @parts = split ipc_separator, $file;
+    my ($global, $hid) = $parts[0] eq 'GLOBAL' ? (1, shift @parts) : (0, join ipc_separator, splice(@parts, 0, 3));
     my ($pid, $tid, $eid) = splice(@parts, 0, 3);
     my $type = join '::' => @parts;
 
@@ -398,7 +398,8 @@ sub DESTROY {
         next if $file =~ m/\.complete$/;
         my $full = File::Spec->catfile($tempdir, $file);
 
-        if ($file =~ m/^(GLOBAL|HUB-)/) {
+        my $sep = ipc_separator;
+        if ($file =~ m/^(GLOBAL|HUB$sep)/) {
             $full =~ m/^(.*)$/;
             $full = $1; # Untaint it
             next if $ENV{T2_KEEP_TEMPDIR};

--- a/lib/Test2/Util.pm
+++ b/lib/Test2/Util.pm
@@ -18,6 +18,8 @@ our @EXPORT_OK = qw{
     CAN_FORK
 
     IS_WIN32
+
+    ipc_separator
 };
 BEGIN { require Exporter; our @ISA = qw(Exporter) }
 
@@ -138,6 +140,8 @@ sub pkg_to_file {
     $file .= '.pm';
     return $file;
 }
+
+sub ipc_separator() { "~" }
 
 1;
 


### PR DESCRIPTION
On windows, forked processes are threads, and reading from $$ gives the thread id instead, which is a negative number. This interferes with the field separator in filenames, so as a quick fix the - in the pid is replaced with a ~ and restored when reading the file.

The commit 8b929f15e3cb2b5ce36bc84010c06a68d69c9f3e should be backed out, as it would only serve to hide this kind of issue.