### PR TITLE
__LINE__ and (caller)[2] may be different under Data::Dumper

### DIFF
--- a/t/Test2/modules/API/Context.t
+++ b/t/Test2/modules/API/Context.t
@@ -67,7 +67,10 @@ wrap {
 my $end_ctx;
 { # Simulate an END block...
     local *END = sub { local *__ANON__ = 'END'; context() };
-    my $ctx = END(); $frame = [ __PACKAGE__, __FILE__, __LINE__, 'main::END' ];
+    my $ctx = END();
+    $frame = [ __PACKAGE__, __FILE__, __LINE__ - 1, 'main::END' ];
+    # "__LINE__ - 1" on the preceding line forces the value to be an IV
+    # (even though __LINE__ on its own is a PV), just as (caller)[2] is.
     $end_ctx = $ctx->snapshot;
     $ctx->release;
 }


### PR DESCRIPTION
The __LINE__ token is compiled as an op_const pointing to an SvPV containing
the stringification of the line number. But (caller)[2] yields an SvIV that
directly represents the line number.

The version of Data::Dumper in blead now uses its XS implementation by
default, even when its Deparse option is enabled; previously, Deparse forced
use of the pure-Perl implementation.

The XS and pure-Perl implementations of Data::Dumper differ slightly: the
pure-Perl implementation always dumps defined non-reference scalars with
quotes, while the XS implementation uses a quote-less representation for
small integers. (The precise differences have changed over time, however.)

Test-Simple/t/Test2/modules/API/Context.t uses the minimal testing library
in Test-Simple/t/tools.pl to test itself, and t/tools.pl in turn implements
is_deeply() by doing the equivalent of is(Dumper($got), Dumper($expected)).
Finally, it does is_deeply() on structures containing a line number, but the
"got" structure contains the result of (caller)[2], while the "expected"
structure contains __LINE__. So now that the dumps of those structures are
different, the test fails.

Fix this by doing arithmetic on the __LINE__, thus forcing it to be an IV.