### PR TITLE
switch version provider plugins

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -3,7 +3,7 @@ author  = Chad Granum <exodist@cpan.org>
 license = Perl_5
 copyright_holder = Chad Granum
 
-[VersionFromModule]
+[RewriteVersion] ; sets dist version from main module's $VERSION
 [License]
 [ManifestSkip]
 [Manifest]


### PR DESCRIPTION
The [VersionFromModule] plugin no longer passes tests, and is no longer being
actively maintained -- but [RewriteVersion] can be used as a drop-in
replacement.

There are no differences in the build output; Test::Builder::IO::Scalar's
special fixed $VERSION is not affected because it is not declared with 'our'.