### PR TITLE
when a subtest forks, do not finish up in both processes

### DIFF
--- a/lib/Test2/API.pm
+++ b/lib/Test2/API.pm
@@ -473,6 +473,7 @@ sub run_subtest {
     }
 
     my $start_pid = $$;
+    my $start_tid = get_tid;
     my ($ok, $err, $finished);
     T2_SUBTEST_WRAPPER: {
         # Do not use 'try' cause it localizes __DIE__
@@ -490,8 +491,13 @@ sub run_subtest {
     }
 
     if ($start_pid != $$) {
-      warn $ok ? "Forked inside subtest, but subtest never finished!\n" : $err;
-      exit 255;
+        warn $ok ? "Forked inside subtest, but subtest never finished!\n" : $err;
+        exit 255;
+    }
+
+    if ($start_tid != get_tid) {
+        warn $ok ? "Started new thread inside subtest, but thread never finished!\n" : $err;
+        exit 255;
     }
 
     $stack->pop($hub);

--- a/lib/Test2/API.pm
+++ b/lib/Test2/API.pm
@@ -472,6 +472,7 @@ sub run_subtest {
         };
     }
 
+    my $start_pid = $$;
     my ($ok, $err, $finished);
     T2_SUBTEST_WRAPPER: {
         # Do not use 'try' cause it localizes __DIE__
@@ -487,6 +488,12 @@ sub run_subtest {
             $finished = 1;
         }
     }
+
+    if ($start_pid != $$) {
+      warn $ok ? "Forked inside subtest, but subtest never finished!\n" : $err;
+      exit 255;
+    }
+
     $stack->pop($hub);
 
     my $trace = $ctx->trace;

--- a/t/Test2/regression/746-forking-subtest.t
+++ b/t/Test2/regression/746-forking-subtest.t
@@ -1,0 +1,34 @@
+use strict;
+use warnings;
+use Test2::IPC;
+use Test2::Tools::Tiny;
+use Test2::API qw/context intercept test2_stack/;
+use Test2::Util qw/CAN_FORK/;
+
+BEGIN {
+    skip_all "System cannot fork" unless CAN_FORK;
+}
+
+my $events = intercept {
+    Test2::API::run_subtest("this subtest forks" => sub {
+        if (fork) {
+            wait;
+            isnt($?, 0, "subprocess died");
+        } else {
+            die "# Expected warning from subtest";
+        };
+    });
+};
+
+my @subtests = grep {; $_->isa('Test2::Event::Subtest') } @$events;
+
+if (is(@subtests, 1, "only one subtest run, effectively")) {
+    my @subokay = grep {; $_->isa('Test2::Event::Ok') }
+                  @{ $subtests[0]->subevents };
+    is(@subokay, 1, "we got one test result inside the subtest");
+    ok(! $subokay[0]->causes_fail, "...and it passed");
+} else {
+  # give up, we're already clearly broken
+}
+
+done_testing;


### PR DESCRIPTION
This patch follows a very brief and inconclusive [mailing list discussion on perl-qa](http://www.nntp.perl.org/group/perl.qa/2016/12/msg13723.html).

Given this sample program:

```perl
  use strict;
  use warnings;
  use Test::More;
  use Test2::API;

  Test2::API::run_subtest("forking subtest" => sub {
    if (fork) {
      wait;
      cmp_ok($?, '!=', 0, "subprocess died");
    } else {
      die "123";
    };
  });

  done_testing;
```

...we'll see the "forking subtest" fail in both processes.  Also, the
subprocess will now exit 0, so the cmp_ok fails.  This is not the same
behavior as Test::Builder's subtests.  Test::Builder tracks whether the
process has forked and, if it has, dies in the child and only finalizes
the subtest in the parent.  This patch brings that behavior to
Test2::API::run_subtest.

Note that Test::Builder also checks whether Test::Sync::IPC has been
loaded before dying in the subtest.  I have not carried that condition
forward, because I can't find that module anywhere.