### PR TITLE
Add 'no_fork' option to run_subtest

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,7 @@
 {{$NEXT}}
 
+    - Add 'no_fork' option to run_subtest()
+
 1.302073  2016-12-18 23:02:54-08:00 America/Los_Angeles
 
     - No changes from last trial

--- a/lib/Test2/API.pm
+++ b/lib/Test2/API.pm
@@ -487,6 +487,23 @@ sub run_subtest {
             $finished = 1;
         }
     }
+
+    if ($params->{no_fork}) {
+        if ($$ != $ctx->trace->pid) {
+            warn $ok ? "Forked inside subtest, but subtest never finished!\n" : $err;
+            exit 255;
+        }
+
+        if (get_tid() != $ctx->trace->tid) {
+            warn $ok ? "Started new thread inside subtest, but thread never finished!\n" : $err;
+            exit 255;
+        }
+    }
+    elsif (!$parent->is_local && !$parent->ipc) {
+        warn $ok ? "A new process or thread was started inside subtest, but IPC is not enabled!\n" : $err;
+        exit 255;
+    }
+
     $stack->pop($hub);
 
     my $trace = $ctx->trace;
@@ -957,6 +974,12 @@ created for the hub that shares the same trace as the current context.
 
 Set this to true if your tool is producing subtests without user-specified
 subs.
+
+=item 'no_fork' => $bool
+
+Defaults to off. Normally forking inside a subtest will actually fork the
+subtest, resulting in 2 final subtest events. This parameter will turn off that
+behavior, only the original process/thread will return a final subtest event.
 
 =back
 

--- a/t/Test2/regression/746-forking-subtest.t
+++ b/t/Test2/regression/746-forking-subtest.t
@@ -1,0 +1,37 @@
+use strict;
+use warnings;
+use Test2::IPC;
+use Test2::Tools::Tiny;
+use Test2::API qw/context intercept test2_stack/;
+use Test2::Util qw/CAN_FORK/;
+
+BEGIN {
+    skip_all "System cannot fork" unless CAN_FORK;
+}
+
+my $events = intercept {
+    Test2::API::run_subtest("this subtest forks" => sub {
+        if (fork) {
+            wait;
+            isnt($?, 0, "subprocess died");
+        } else {
+            # Prevent the exception from being rendered to STDERR, people have
+            # complained about STDERR noise in tests before.
+            close STDERR;
+            die "# Expected warning from subtest";
+        };
+    }, {no_fork => 1});
+};
+
+my @subtests = grep {; $_->isa('Test2::Event::Subtest') } @$events;
+
+if (is(@subtests, 1, "only one subtest run, effectively")) {
+    my @subokay = grep {; $_->isa('Test2::Event::Ok') }
+                  @{ $subtests[0]->subevents };
+    is(@subokay, 1, "we got one test result inside the subtest");
+    ok(! $subokay[0]->causes_fail, "...and it passed");
+} else {
+  # give up, we're already clearly broken
+}
+
+done_testing;


### PR DESCRIPTION
This is an alternate fix for #746 

@rjbs 