### PR TITLE
Combine messages into one diag event in Test::Builder::_ok_debug

### DIFF
--- a/lib/Test/Builder.pm
+++ b/lib/Test/Builder.pm
@@ -675,8 +675,7 @@ sub _ok_debug {
 
     my (undef, $file, $line) = $trace->call;
     if (defined $orig_name) {
-        $self->diag(qq[  $msg test '$orig_name'\n]);
-        $self->diag(qq[  at $file line $line.\n]);
+        $self->diag(qq[  $msg test '$orig_name'\n  at $file line $line.\n]);
     }
     else {
         $self->diag(qq[  $msg test at $file line $line.\n]);

--- a/t/Legacy_And_Test2/diag_event_on_ok.t
+++ b/t/Legacy_And_Test2/diag_event_on_ok.t
@@ -1,0 +1,21 @@
+use strict;
+use warnings;
+
+use Test2::Tools::Tiny;
+use Test2::API qw/intercept/;
+use Test::More ();
+
+my $events = intercept {
+    Test::More::ok(0, 'name');
+};
+
+my ($ok, $diag) = @$events;
+
+ok($ok->isa('Test2::Event::Ok'), "got 'ok' result");
+is($ok->pass, 0, "'ok' test failed");
+is($ok->name, 'name', "got 'ok' name");
+
+ok($diag->isa('Test2::Event::Diag'), "got 'ok' result");
+is($diag->message, "  Failed test 'name'\n  at $0 line 9.\n", "got all diag message in one diag event");
+
+done_testing;


### PR DESCRIPTION
`Test::Builder::ok` (`Test::Builder::_ok_debug`) sends two `Diag` events after a test failed when the name of test is defined. However `Test2::Tools::Tiny::ok` sends one `Diag` event. It's difficult to test with `intercept` and `fail_events` in a situation where these are mixed.
This p-r changes `Test::Builder::_ok_debug` to be combine messages into one `Diag` event.

```perl
use strict;
use warnings;
use Data::Dumper;
use Test2::API qw/intercept/;
use Test2::Tools::Tiny ();
use Test::More ();

$Data::Dumper::Indent   = 1;
$Data::Dumper::Sortkeys = 1;
$Data::Dumper::Useqq    = 1;

warn "# Test::More::ok\n";
warn Dumper(intercept { Test::More::ok(0, 'name') });

warn "# Test::Tools::Tiny::ok\n";
warn Dumper(intercept { Test2::Tools::Tiny::ok(0, 'name') });
```

<details>
<summary>Result</summary>

```
# Test::More::ok
$VAR1 = [
  bless( {
    "_meta" => {
      "Test::Builder" => {
        "actual_ok" => 0,
        "name" => "name",
        "ok" => 0,
        "reason" => "",
        "type" => ""
      }
    },
    "effective_pass" => 0,
    "name" => "name",
    "pass" => 0,
    "trace" => bless( {
      "cid" => "C3",
      "frame" => [
        "main",
        "test.pl",
        13,
        "Test::More::ok"
      ],
      "pid" => 70876,
      "tid" => 0
    }, 'Test2::Util::Trace' )
  }, 'Test2::Event::Ok' ),
  bless( {
    "message" => "  Failed test 'name'\n",
    "trace" => bless( {
      "cid" => "C3",
      "frame" => $VAR1->[0]{"trace"}{"frame"},
      "pid" => 70876,
      "tid" => 0
    }, 'Test2::Util::Trace' )
  }, 'Test2::Event::Diag' ),
  bless( {
    "message" => "  at test.pl line 13.\n",
    "trace" => bless( {
      "cid" => "C3",
      "frame" => $VAR1->[0]{"trace"}{"frame"},
      "pid" => 70876,
      "tid" => 0
    }, 'Test2::Util::Trace' )
  }, 'Test2::Event::Diag' )
];
# Test::Tools::Tiny::ok
$VAR1 = [
  bless( {
    "effective_pass" => 0,
    "name" => "name",
    "pass" => 0,
    "trace" => bless( {
      "cid" => "C5",
      "frame" => [
        "main",
        "test.pl",
        16,
        "Test2::Tools::Tiny::ok"
      ],
      "pid" => 70876,
      "tid" => 0
    }, 'Test2::Util::Trace' )
  }, 'Test2::Event::Ok' ),
  bless( {
    "message" => "Failed test 'name'\nat test.pl line 16.\n",
    "trace" => bless( {
      "cid" => "C5",
      "frame" => $VAR1->[0]{"trace"}{"frame"},
      "pid" => 70876,
      "tid" => 0
    }, 'Test2::Util::Trace' )
  }, 'Test2::Event::Diag' )
];
```

</details>

<details>
<summary>Result after applying this p-r changes</summary>

```
# Test::More::ok
$VAR1 = [
  bless( {
    "_meta" => {
      "Test::Builder" => {
        "actual_ok" => 0,
        "name" => "name",
        "ok" => 0,
        "reason" => "",
        "type" => ""
      }
    },
    "effective_pass" => 0,
    "name" => "name",
    "pass" => 0,
    "trace" => bless( {
      "cid" => "C3",
      "frame" => [
        "main",
        "test.pl",
        13,
        "Test::More::ok"
      ],
      "pid" => 71001,
      "tid" => 0
    }, 'Test2::Util::Trace' )
  }, 'Test2::Event::Ok' ),
  bless( {
    "message" => "  Failed test 'name'\n  at test.pl line 13.\n",
    "trace" => bless( {
      "cid" => "C3",
      "frame" => $VAR1->[0]{"trace"}{"frame"},
      "pid" => 71001,
      "tid" => 0
    }, 'Test2::Util::Trace' )
  }, 'Test2::Event::Diag' )
];
```

</details>