### PR TITLE
Add optimal_pass_tap method to Test2::Formatter::TAP

### DIFF
--- a/lib/Test2/Formatter/TAP.pm
+++ b/lib/Test2/Formatter/TAP.pm
@@ -117,7 +117,20 @@ sub write {
 
 sub print_optimal_pass {
     my ($self, $e, $num) = @_;
+    my $ok = $self->optimal_pass_tap($e,$num);
+    return unless $ok;
 
+    my $io = $self->{+HANDLES}->[OUT_STD];
+
+    local($\, $,) = (undef, '') if $\ || $,;
+    print $io $ok;
+    $self->{+_LAST_FH} = $io;
+
+    return 1;
+}
+
+sub optimal_pass_tap {
+    my ($self, $e, $num) = @_;
     my $type = ref($e);
 
     # Only optimal if this is a Pass or a passing Ok
@@ -138,13 +151,7 @@ sub print_optimal_pass {
         $ok = "$indent$ok";
     }
 
-    my $io = $self->{+HANDLES}->[OUT_STD];
-
-    local($\, $,) = (undef, '') if $\ || $,;
-    print $io $ok;
-    $self->{+_LAST_FH} = $io;
-
-    return 1;
+    return $ok;
 }
 
 sub event_tap {


### PR DESCRIPTION
I want to get TAP generated by `Test2::Formatter::TAP` for too old test module (e.g. `Test::More::Color`)
How about separating `print_optimal_pass` method into generating part and printing part ?

In addition, it seems to be useful for making `Test2::Fomatter::*` that inherited `Test2::Formatter::TAP`.