### PR TITLE
Implementation of regexp handling in check_test for diag

### DIFF
--- a/lib/Test/Tester.pm
+++ b/lib/Test/Tester.pm
@@ -6,7 +6,7 @@ BEGIN
 {
 	if (*Test::Builder::new{CODE})
 	{
-		warn "You should load Test::Tester before Test::Builder (or anything that loads Test::Builder)" 
+		warn "You should load Test::Tester before Test::Builder (or anything that loads Test::Builder)"
 	}
 }
 
@@ -173,15 +173,28 @@ sub cmp_result
 
 	if (defined(my $exp = $expect->{diag}))
 	{
-		# if there actually is some diag then put a \n on the end if it's not
-		# there already
 
-		$exp .= "\n" if (length($exp) and $exp !~ /\n$/);
-		if (not $Test->ok($result->{diag} eq $exp,
-			"subtest '$sub_name' of '$name' compare diag")
-		)
-		{
-			my $got = $result->{diag};
+        my $got = '';
+        if (ref $exp eq 'Regexp') {
+
+            if (not $Test->like($result->{diag}, $exp,
+                "subtest '$sub_name' of '$name' compare diag"))
+            {
+                $got = $result->{diag};
+            }
+
+        } else {
+
+            # if there actually is some diag then put a \n on the end if it's not
+            # there already
+            $exp .= "\n" if (length($exp) and $exp !~ /\n$/);
+
+            if (not $Test->ok($result->{diag} eq $exp,
+    			"subtest '$sub_name' of '$name' compare diag"))
+            {
+                $got = $result->{diag};
+            }
+
 			my $glen = length($got);
 			my $elen = length($exp);
 			for ($got, $exp)
@@ -199,14 +212,14 @@ sub cmp_result
 				} @lines);
 			}
 
-			$Test->diag(<<EOM);
+    		$Test->diag(<<EOM);
 Got diag ($glen bytes):
 $got
 Expected diag ($elen bytes):
 $exp
 EOM
 
-		}
+        }
 	}
 }
 
@@ -315,6 +328,23 @@ Test::Tester - Ease testing test modules built with Test::Builder
 
 or
 
+  use Test::Tester tests => 6;
+
+  use Test::MyStyle;
+
+  check_test(
+    sub {
+      is_mystyle_qr("this", "that", "not mathing");
+    },
+    {
+      ok => 0, # expect this to fail
+      name => "not mathing",
+      diag => qr/Expected: 'this'\s+Got: 'that'/,
+    }
+  );
+
+or
+
   use Test::Tester;
 
   use Test::More tests => 3;
@@ -378,6 +408,16 @@ you can get direct access to the test results:
 
   like($result[0]->{diag}, "/^Database ping took \\d+ seconds$"/, "diag");
 
+or
+
+  check_test(
+    sub { is_mystyle_qr("this", "that", "not mathing") },
+    {
+      ok => 0, # we expect the test to fail
+      name => "not matching",
+      diag => qr/Expected: 'this'\s+Got: 'that'/,
+    }
+  );
 
 We cannot predict how long the database ping will take so we use
 Test::More's like() test to check that the diagnostic string is of the right

--- a/lib/Test/Tester.pm
+++ b/lib/Test/Tester.pm
@@ -334,11 +334,11 @@ or
 
   check_test(
     sub {
-      is_mystyle_qr("this", "that", "not mathing");
+      is_mystyle_qr("this", "that", "not matching");
     },
     {
       ok => 0, # expect this to fail
-      name => "not mathing",
+      name => "not matching",
       diag => qr/Expected: 'this'\s+Got: 'that'/,
     }
   );
@@ -411,7 +411,7 @@ you can get direct access to the test results:
 or
 
   check_test(
-    sub { is_mystyle_qr("this", "that", "not mathing") },
+    sub { is_mystyle_qr("this", "that", "not matching") },
     {
       ok => 0, # we expect the test to fail
       name => "not matching",

--- a/t/Legacy/check_tests.t
+++ b/t/Legacy/check_tests.t
@@ -5,7 +5,7 @@ use Test::Tester;
 use Data::Dumper qw(Dumper);
 
 my $test = Test::Builder->new;
-$test->plan(tests => 105);
+$test->plan(tests => 139);
 
 my $cap;
 
@@ -95,6 +95,34 @@ my @tests = (
 			depth => 0,
 		},
 	],
+    [
+        'pass diag qr',
+        '$cap->ok(1, "pass diag qr");
+        $cap->diag("pass diag qr");',
+        {
+            name => "pass diag qr",
+            ok => 1,
+            actual_ok => 1,
+            reason => "",
+            type => "",
+            diag => qr/pass diag qr/,
+            depth => 0,
+        },
+    ],
+    [
+        'fail diag qr',
+        '$cap->ok(0, "fail diag qr");
+        $cap->diag("fail diag qr");',
+        {
+            name => "fail diag qr",
+            ok => 0,
+            actual_ok => 0,
+            reason => "",
+            type => "",
+            diag => qr/fail diag qr/,
+            depth => 0,
+        },
+    ],
 );
 
 my $big_code = "";


### PR DESCRIPTION
This PR implements handling in `check_test` for `diag`, so it is possible to pass a regular expression instead of a string for comparison.

```perl
  check_test(
    sub {
      is_mystyle_qr("this", "that", "not mathing");
    },
    {
      ok => 0, # expect this to fail
      name => "not mathing",
      diag => qr/Expected: 'this'\s+Got: 'that'/,
    }
  );
```

I have only implemented basic tests, please evaluate and get back to me if useful, needs improvements or discard it if useless...