### PR TITLE
proposal: set coderef name for subtests

### DIFF
--- a/lib/Test/Builder.pm
+++ b/lib/Test/Builder.pm
@@ -13,6 +13,7 @@ BEGIN {
 }
 
 use Scalar::Util qw/blessed reftype weaken/;
+use Sub::Util qw/subname set_subname/;
 
 use Test2::Util qw/USE_THREADS try get_tid/;
 use Test2::API qw/context release/;
@@ -318,6 +319,10 @@ sub subtest {
         unless $code && reftype($code) eq 'CODE';
 
     $name ||= "Child of " . $self->name;
+
+    my $sub_name = subname($code);
+    $sub_name =~ s/(?<=:)__ANON__.*$/$name/
+        and set_subname($sub_name,$code);
 
     $ctx->note("Subtest: $name");
 

--- a/t/Legacy/subtest/die.t
+++ b/t/Legacy/subtest/die.t
@@ -17,11 +17,12 @@ my $Test = Test::Builder->new;
 
     $Test->ok( !eval {
         $tb->subtest("death" => sub {
-            die "Death in the subtest";
+            my $name = (caller(0))[3];
+            die "Death in the subtest ($name)";
         });
         1;
     });
-    $Test->like( $@, qr/^Death in the subtest at \Q$0\E line /);
+    $Test->like( $@, qr/^Death in the subtest \(main::death\) at \Q$0\E line /);
 
     $Test->ok( !$tb->parent, "the parent object is restored after a die" );
 }


### PR DESCRIPTION
if `subtest` is invoked with an anonymous coderef, we set its name to the name of the subtest, to simplify reading stacktraces

idea inspired by [`Test::Subtest::Attribute`](https://metacpan.org/release/BMARCOTTE/Test-Subtest-Attribute-0.01)