### PR TITLE
add pre-subtest callbacks

### DIFF
--- a/lib/Test/Builder.pm
+++ b/lib/Test/Builder.pm
@@ -319,6 +319,10 @@ sub subtest {
 
     $name ||= "Child of " . $self->name;
 
+
+    $_->($name,$code,@args)
+        for Test2::API::test2_list_pre_subtest_callbacks();
+
     $ctx->note("Subtest: $name");
 
     my $child = $self->child($name);

--- a/lib/Test2/API.pm
+++ b/lib/Test2/API.pm
@@ -100,12 +100,14 @@ our @EXPORT_OK = qw{
     test2_add_callback_context_release
     test2_add_callback_exit
     test2_add_callback_post_load
+    test2_add_callback_pre_subtest
     test2_list_context_aquire_callbacks
     test2_list_context_acquire_callbacks
     test2_list_context_init_callbacks
     test2_list_context_release_callbacks
     test2_list_exit_callbacks
     test2_list_post_load_callbacks
+    test2_list_pre_subtest_callbacks
 
     test2_ipc
     test2_ipc_drivers
@@ -172,12 +174,14 @@ sub test2_add_callback_context_init      { $INST->add_context_init_callback(@_) 
 sub test2_add_callback_context_release   { $INST->add_context_release_callback(@_) }
 sub test2_add_callback_exit              { $INST->add_exit_callback(@_) }
 sub test2_add_callback_post_load         { $INST->add_post_load_callback(@_) }
+sub test2_add_callback_pre_subtest       { $INST->add_pre_subtest_callback(@_) }
 sub test2_list_context_aquire_callbacks  { @{$INST->context_acquire_callbacks} }
 sub test2_list_context_acquire_callbacks { @{$INST->context_acquire_callbacks} }
 sub test2_list_context_init_callbacks    { @{$INST->context_init_callbacks} }
 sub test2_list_context_release_callbacks { @{$INST->context_release_callbacks} }
 sub test2_list_exit_callbacks            { @{$INST->exit_callbacks} }
 sub test2_list_post_load_callbacks       { @{$INST->post_load_callbacks} }
+sub test2_list_pre_subtest_callbacks     { @{$INST->pre_subtest_callbacks} }
 
 sub test2_ipc                 { $INST->ipc }
 sub test2_ipc_add_driver      { $INST->add_ipc_driver(@_) }
@@ -509,6 +513,9 @@ sub _intercept {
 
 sub run_subtest {
     my ($name, $code, $params, @args) = @_;
+
+    $_->($name,$code,@args)
+        for Test2::API::test2_list_pre_subtest_callbacks();
 
     $params = {buffered => $params} unless ref $params;
     my $inherit_trace = delete $params->{inherit_trace};
@@ -1294,6 +1301,12 @@ callback will receive the newly created context as its only argument.
 Add a callback that will be called every time a context is released. The
 callback will receive the released context as its only argument.
 
+=item test2_add_callback_pre_subtest(sub { ... })
+
+Add a callback that will be called every time a subtest is going to be
+run. The callback will receive the subtest name, coderef, and any
+arguments.
+
 =item @list = test2_list_context_acquire_callbacks()
 
 Return all the context acquire callback references.
@@ -1313,6 +1326,10 @@ Returns all the exit callback references.
 =item @list = test2_list_post_load_callbacks()
 
 Returns all the post load callback references.
+
+=item @list = test2_list_pre_subtest_callbacks()
+
+Returns all the pre-subtest callback references.
 
 =back
 

--- a/t/Legacy/subtest/callback.t
+++ b/t/Legacy/subtest/callback.t
@@ -1,0 +1,53 @@
+#!/usr/bin/perl -w
+
+# What happens when a subtest dies?
+
+use lib 't/lib';
+
+use strict;
+use Test::More;
+use Test::Builder;
+use Test2::API;
+
+my $Test = Test::Builder->new;
+
+my $step = 0;
+my @callback_calls = ();
+Test2::API::test2_add_callback_pre_subtest(
+    sub {
+        $Test->is_num(
+            $step,
+            0,
+            'pre-subtest callbacks should be invoked before the subtest',
+        );
+        ++$step;
+        push @callback_calls, [@_];
+    },
+);
+
+$Test->subtest(
+    (my $subtest_name='some subtest'),
+    (my $subtest_code=sub {
+         $Test->is_num(
+             $step,
+             1,
+             'subtest should be run after the pre-subtest callbacks',
+         );
+         ++$step;
+     }),
+    (my @subtest_args = (1,2,3)),
+);
+
+is_deeply(
+    \@callback_calls,
+    [[$subtest_name,$subtest_code,@subtest_args]],
+    'pre-subtest callbacks should be invoked with the expected arguments',
+);
+
+$Test->is_num(
+    $step,
+    2,
+    'the subtest should be run',
+);
+
+$Test->done_testing();

--- a/t/Test2/behavior/Subtest_callback.t
+++ b/t/Test2/behavior/Subtest_callback.t
@@ -1,0 +1,48 @@
+use strict;
+use warnings;
+
+use Test2::Tools::Tiny;
+
+use Test2::API qw/run_subtest intercept/;
+
+my $step = 0;
+my @callback_calls = ();
+Test2::API::test2_add_callback_pre_subtest(
+    sub {
+        is(
+            $step,
+            0,
+            'pre-subtest callbacks should be invoked before the subtest',
+        );
+        ++$step;
+        push @callback_calls, [@_];
+    },
+);
+
+run_subtest(
+    (my $subtest_name='some subtest'),
+    (my $subtest_code=sub {
+         is(
+             $step,
+             1,
+             'subtest should be run after the pre-subtest callbacks',
+         );
+         ++$step;
+     }),
+    undef,
+    (my @subtest_args = (1,2,3)),
+);
+
+is_deeply(
+    \@callback_calls,
+    [[$subtest_name,$subtest_code,@subtest_args]],
+    'pre-subtest callbacks should be invoked with the expected arguments',
+);
+
+is(
+    $step,
+    2,
+    'the subtest should be run',
+);
+
+done_testing;

--- a/t/Test2/modules/API/Instance.t
+++ b/t/Test2/modules/API/Instance.t
@@ -36,6 +36,7 @@ is_deeply(
         context_acquire_callbacks => [],
         context_init_callbacks    => [],
         context_release_callbacks => [],
+        pre_subtest_callbacks     => [],
 
         stack => [],
     },
@@ -69,6 +70,7 @@ is_deeply(
         context_acquire_callbacks => [],
         context_init_callbacks    => [],
         context_release_callbacks => [],
+        pre_subtest_callbacks     => [],
 
         stack => [],
     },
@@ -152,6 +154,18 @@ like(
     exception { $one->add_exit_callback({}) },
     qr/End callbacks must be coderefs/,
     "Exit callbacks must be coderefs"
+);
+
+$one->reset;
+$one->add_pre_subtest_callback($callback);
+is(@{$one->pre_subtest_callbacks}, 1, "added a pre-subtest callback");
+$one->add_pre_subtest_callback($callback);
+is(@{$one->pre_subtest_callbacks}, 2, "added another pre-subtest callback");
+
+like(
+    exception { $one->add_pre_subtest_callback({}) },
+    qr/Pre-subtest callbacks must be coderefs/,
+    "Pre-subtest callbacks must be coderefs"
 );
 
 if (CAN_REALLY_FORK) {


### PR DESCRIPTION
as suggested in #800 

`Test2::API` now has pre-subtest callbacks.

I'm not sure that the way I wrote the `t/Legacy/subtest/callback.t` is the best way, I'm not clear on what I can and can not use.