### PR TITLE
add missing whatis entry

### DIFF
--- a/lib/Test2/EventFacet/Hub.pm
+++ b/lib/Test2/EventFacet/Hub.pm
@@ -20,7 +20,7 @@ __END__
 
 =head1 NAME
 
-Test2::EventFacet::Hub
+Test2::EventFacet::Hub - Facet for the hubs an event passes through.
 
 =head1 DESCRIPTION
 


### PR DESCRIPTION

In Debian we are currently applying the following patch to
Test-Simple.
We thought you might be interested in it too.

    Description: add missing whatis entry
    Origin: vendor
    Author: gregor herrmann <gregoa@debian.org>
    Last-Update: 2018-03-10
    

The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/libtest-simple-perl/raw/master/debian/patches/pod.patch

Thanks for considering,
  gregor herrmann,
  Debian Perl Group
