### PR TITLE
fixed Test2::EventFacet::Parent's abstract

### DIFF
--- a/lib/Test2/EventFacet/Parent.pm
+++ b/lib/Test2/EventFacet/Parent.pm
@@ -26,7 +26,7 @@ __END__
 
 =head1 NAME
 
-Test2::EventFacet::Parent - Base class for all event facets.
+Test2::EventFacet::Parent - Facet for events contains other events
 
 =head1 DESCRIPTION
 


### PR DESCRIPTION
The content of abstract is the same as Test2::EventFacet.
It is necessary to change to the contents of Test2::EventFacet::Parent.