### PR TITLE
fixed Test2::Formatter's doc

### DIFF
--- a/lib/Test2/Formatter.pm
+++ b/lib/Test2/Formatter.pm
@@ -92,12 +92,6 @@ The C<finalize> method is always the last thing called on the formatter, I<<
 except when C<terminate> is called for a Bail event >>. It is passed the
 following arguments:
 
-The C<new_root> method is called when C<Test2::API::Stack> Initializes the root
-hub for the first time. Most formatters will simply have this call C<<
-$class->new >>, which is the default behavior. Some formatters however may want
-to take extra action during construction of the root formatter, this is where
-they can do that.
-
 =over 4
 
 =item * The number of tests that were planned
@@ -111,6 +105,12 @@ they can do that.
 =item * A boolean indicating whether or not this call is for a subtest
 
 =back
+
+The C<new_root> method is called when C<Test2::API::Stack> Initializes the root
+hub for the first time. Most formatters will simply have this call C<<
+$class->new >>, which is the default behavior. Some formatters however may want
+to take extra action during construction of the root formatter, this is where
+they can do that.
 
 =head1 SOURCE
 


### PR DESCRIPTION
Move the list of parameters of the finalize method to the appropriate place.