### PR TITLE
delay checking for table support until requested

### DIFF
--- a/lib/Test2/Formatter/TAP.pm
+++ b/lib/Test2/Formatter/TAP.pm
@@ -16,16 +16,17 @@ sub OUT_ERR() { 1 }
 
 BEGIN { require Test2::Formatter; our @ISA = qw(Test2::Formatter) }
 
-# Not constants because this is a method, and can be overriden
-BEGIN {
-    local $SIG{__DIE__} = 'DEFAULT';
-    local $@;
-    if (($INC{'Term/Table.pm'} && $INC{'Term/Table/Util.pm'}) || eval { require Term::Table; require Term::Table::Util; 1 }) {
-        *supports_tables = sub { 1 };
+my $supports_tables;
+sub supports_tables {
+    if (!defined $supports_tables) {
+        local $SIG{__DIE__} = 'DEFAULT';
+        local $@;
+        $supports_tables
+            = ($INC{'Term/Table.pm'} && $INC{'Term/Table/Util.pm'})
+            || eval { require Term::Table; require Term::Table::Util; 1 }
+            || 0;
     }
-    else {
-        *supports_tables = sub { 0 };
-    }
+    return $supports_tables;
 }
 
 sub _autoflush {


### PR DESCRIPTION
Rather than checking if Term::Table can be loaded at compile time, wait
until table support is actually requested.  Term::Table will load a
number of extra modules, including Unicode::GCString.

Loading the extra modules slows down startup time, but can also lead to
changes in global destruction order.  If a test interacts with Test2
during global destruction, it is likely to cause warnings or errors due
to this.

While it may make sense to make adjustments to the behavior during
global destruction to be more robust, simply delaying loading of
Term::Table has speed benefits as well.

Fixes #837