### PR TITLE
Test2/Formatter/TAP.pm; Fix to work on EBCDIC systems

### DIFF
--- a/lib/Test2/Formatter/TAP.pm
+++ b/lib/Test2/Formatter/TAP.pm
@@ -271,7 +271,10 @@ sub assert_tap {
         }
 
         my %seen;
-        my @order = grep { !$seen{$_}++ } sort keys %directives;
+
+        # Sort so that TODO comes before skip even on systems where lc sorts
+        # before uc, as other code depends on that ordering.
+        my @order = grep { !$seen{$_}++ } sort { lc $b cmp lc $a } keys %directives;
 
         $directives = ' # ' . join ' & ' => @order;
 


### PR DESCRIPTION
There is code that is looking for the string 'TODO & skip', which was
based on the fact that on ASCII platforms any uppercase ASCII character
sorts by default to before every lowercase one.

This isn't true on EBCDIC platforms, so change the sort to explicitly
make T come before s

With this one line code change, Test2 passes all its tests on an EBCDIC z/OS system.  When I first tried things out there several months ago, a few more tests were failing, but those somehow went away in the interim.  This commit fixes the remaining failing tests.

There are other ways to fix this, but this seemed like the simplest for me to do, given that I'm not familiar with the nuances of the code as a whole.