### PR TITLE
Avoid to raise warnings from info / debug tap

### DIFF
--- a/lib/Test/Builder/Formatter.pm
+++ b/lib/Test/Builder/Formatter.pm
@@ -33,7 +33,8 @@ sub debug_tap {
     my ($self, $f, $num) = @_;
     return if $self->{+NO_DIAG};
     my @out = $self->SUPER::debug_tap($f, $num);
-    $self->redirect(\@out) if @out && $f->{about}->{package} eq 'Test::Builder::TodoDiag';
+    $self->redirect(\@out) if @out && ref $f->{about} && defined $f->{about}->{package}
+        && $f->{about}->{package} eq 'Test::Builder::TodoDiag';
     return @out;
 }
 
@@ -41,7 +42,8 @@ sub info_tap {
     my ($self, $f) = @_;
     return if $self->{+NO_DIAG};
     my @out = $self->SUPER::info_tap($f);
-    $self->redirect(\@out) if @out && $f->{about}->{package} eq 'Test::Builder::TodoDiag';
+    $self->redirect(\@out) if @out && ref $f->{about} && defined $f->{about}->{package}
+        && $f->{about}->{package} eq 'Test::Builder::TodoDiag';
     return @out;
 }
 


### PR DESCRIPTION
noticed this error while using the TRIAL version 0.9990002 for Test2::Harness 

```
	Use of uninitialized value in string eq at /usr/local/cpanel/3rdparty/perl/530/lib/perl5/cpanel_lib/Test/Builder/Formatter.pm line 44.
 at /usr/local/cpanel/3rdparty/perl/530/lib/perl5/cpanel_lib/Test/Builder/Formatter.pm line 44.
	Test::Builder::Formatter::info_tap(Test::Builder::Formatter=HASH(0x18c1b30), HASH(0x3ec1e30)) called at /usr/local/cpanel/3rdparty/perl/530/lib/perl5/cpanel_lib/Test2/Formatter/TAP.pm line 181
	Test2::Formatter::TAP::event_tap(Test::Builder::Formatter=HASH(0x18c1b30), HASH(0x3ec1e30), 12) called at /usr/local/cpanel/3rdparty/perl/530/lib/perl5/cpanel_lib/Test2/Formatter/TAP.pm line 102
	Test2::Formatter::TAP::write(Test::Builder::Formatter=HASH(0x18c1b30), Test2::Event::V2=HASH(0x3dacf30), 12, HASH(0x3ec1e30)) called at /usr/local/cpanel/3rdparty/perl/530/lib/perl5/cpanel_lib/Test2/Hub.pm line 373
	Test2::Hub::process(Test2::Hub=HASH(0x182acb0), Test2::Event::V2=HASH(0x3dacf30)) called at /usr/local/cpanel/3rdparty/perl/530/lib/perl5/cpanel_lib/Test2/Hub.pm line 306
	Test2::Hub::send(Test2::Hub=HASH(0x182acb0), Test2::Event::V2=HASH(0x3dacf30)) called at /usr/local/cpanel/3rdparty/perl/530/lib/perl5/cpanel_lib/Test2/API/Context.pm line 232
	Test2::API::Context::send_ev2(Test2::API::Context=HASH(0x3cdce78), "info", ARRAY(0x3ec1ea8)) called at /usr/local/cpanel/3rdparty/perl/530/lib/perl5/cpanel_lib/Test2/API/Context.pm line 211
	Test2::API::Context::send_ev2_and_release(Test2::API::Context=HASH(0x3cdce78), "info", ARRAY(0x3ec1ea8)) called at /usr/local/cpanel/3rdparty/perl/530/lib/perl5/cpanel_lib/Test2/Plugin/IOEvents/Tie.pm line 55
	Test2::Plugin::IOEvents::Tie::PRINT(Test2::Plugin::IOEvents::Tie=ARRAY(0x1859408), "[2020-02-25 13:12:10 -0600]
```