### PR TITLE
avoid closing over scalar in BEGIN block in cmp_ok eval

### DIFF
--- a/lib/Test/Builder.pm
+++ b/lib/Test/Builder.pm
@@ -963,10 +963,13 @@ sub cmp_ok {
 
         my($pack, $file, $line) = $ctx->trace->call();
         my $warning_bits = $ctx->trace->warning_bits;
+        # convert this to a code string so the BEGIN doesn't have to close
+        # over it, which can lead to issues with Devel::Cover
+        my $bits_code = defined $warning_bits ? qq["\Q$warning_bits\E"] : 'undef';
 
         # This is so that warnings come out at the caller's level
         $succ = eval qq[
-BEGIN {\${^WARNING_BITS} = \$warning_bits};
+BEGIN {\${^WARNING_BITS} = $bits_code};
 #line $line "(eval in cmp_ok) $file"
 \$test = (\$got $type \$expect);
 1;

--- a/t/Legacy/Regression/is_capture.t
+++ b/t/Legacy/Regression/is_capture.t
@@ -1,0 +1,20 @@
+use strict;
+use warnings;
+use Test2::Tools::Tiny;
+
+# this test is only relevant under Devel::Cover
+
+require Test::More;
+
+my $destroy = 0;
+sub CountDestroy::DESTROY { $destroy++ }
+
+my $obj = bless {}, 'CountDestroy';
+
+Test::More::is($obj, $obj, 'compare object to itself using is');
+
+undef $obj;
+
+is $destroy, 1, 'undef object destroyed after being passed to is';
+
+done_testing;


### PR DESCRIPTION
When comparing values using cmp_ok, a string eval is used to check using
the correct op. It also carries through the caller's warnings. If the
BEGIN inside the eval closes over a variable, it slightly alters how the
eval works. This leads to Devel::Cover tracking it like a sub, which
means it holds on to both the op tree, and the values it closes over.
That includes the values that are being compared. This means that
any references passed to Test::More::is would not be destroyed until
process end.

Avoid this by converting the warnings bits value to a string, and
inlining that in the generated code.