### PR TITLE
avoid using ' package separator for isn't function

### DIFF
--- a/lib/Test/More.pm
+++ b/lib/Test/More.pm
@@ -411,8 +411,8 @@ sub isnt ($$;$) {
     return $tb->isnt_eq(@_);
 }
 
-*isn't = \&isnt;
-# ' to unconfuse syntax higlighters
+# make this available as isn't()
+*isn::t = \&isnt;
 
 =item B<like>
 

--- a/t/Legacy/More.t
+++ b/t/Legacy/More.t
@@ -24,7 +24,7 @@ require_ok('Test::More');
 ok( 2 eq 2,             'two is two is two is two' );
 is(   "foo", "foo",       'foo is foo' );
 isnt( "foo", "bar",     'foo isnt bar');
-isn't("foo", "bar",     'foo isn\'t bar');
+isn::t("foo", "bar",     'foo isn\'t bar');
 
 #'#
 like("fooble", '/^foo/',    'foo is like fooble');

--- a/t/Legacy/fail-more.t
+++ b/t/Legacy/fail-more.t
@@ -133,7 +133,7 @@ OUT
 ERR
 
 #line 132
-isn't("foo", "foo",'foo isn\'t foo?' );
+isn::t("foo", "foo",'foo isn\'t foo?' );
 out_ok( <<OUT, <<ERR );
 not ok - foo isn't foo?
 OUT


### PR DESCRIPTION
Test::More provides the isnt() function. Since perl allows single quotes
to be used as package separators, this function is also "cleverly" made
available as isn't(). This is exactly equivalent to installing it as
isn::t.

In the future, perl may deprecate or remove single quote package
separators, so stop using the "isn't" form in our code. The function is
still installed in the same location, so users are free to continue
using it, putting the compatibility burden on them rather than
Test::More.