### PR TITLE
Fix #890

### DIFF
--- a/lib/Test/Builder.pm
+++ b/lib/Test/Builder.pm
@@ -767,7 +767,7 @@ sub _unoverload {
         require overload;
     }
     my $string_meth = overload::Method( $$thing, $type ) || return;
-    $$thing = $$thing->$string_meth();
+    $$thing = $$thing->$string_meth(undef, 0);
 }
 
 sub _unoverload_str {

--- a/t/lib/MyOverload.pm
+++ b/t/lib/MyOverload.pm
@@ -24,7 +24,13 @@ use strict;
 our @ISA = qw(Overloaded);
 
 use overload
-  q{""} => sub { $_[0]->{string} },
-  q{0+} => sub { $_[0]->{num} };
+  q{""} => sub {
+    @_ == 3 or die "Expected 3 parameters";
+    $_[0]->{string};
+  },
+  q{0+} => sub {
+    @_ == 3 or die "Expected 3 parameters";
+    $_[0]->{num};
+  };
 
 1;


### PR DESCRIPTION
Methods used in overload should always be invoked with 3 parameters.