### PR TITLE
remove invalid unused import from File::Spec

### DIFF
--- a/t/Test2/modules/IPC/Driver/Files.t
+++ b/t/Test2/modules/IPC/Driver/Files.t
@@ -1,7 +1,7 @@
 use Test2::Tools::Tiny;
 use Test2::Util qw/get_tid USE_THREADS try ipc_separator/;
 use File::Temp qw/tempfile/;
-use File::Spec qw/catfile/;
+use File::Spec;
 use List::Util qw/shuffle/;
 use strict;
 use warnings;


### PR DESCRIPTION
File::Spec does not export, so the attempted import was being ignored.
catfile is being correctly used as a class method, so the import is not
needed.