### PR TITLE
Don't use git.io for cpm sources

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -27,7 +27,7 @@ jobs:
       - name: perl -V
         run: perl -V
       - name: Install Dependencies
-        run: curl -sL https://git.io/cpm | perl - install -g --show-build-log-on-failure
+        run: curl -sL https://github.com/Test-More/test-more/ | perl - install -g --show-build-log-on-failure
       - name: perl Makefile.PL
         run: perl Makefile.PL
       - name: make

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -28,7 +28,7 @@ jobs:
       - name: perl -V
         run: perl -V
       - name: Install Dependencies
-        run: curl -sL https://git.io/cpm | perl - install -g --show-build-log-on-failure
+        run: curl -sL https://github.com/Test-More/test-more/ | perl - install -g --show-build-log-on-failure
       - name: perl Makefile.PL
         run: perl Makefile.PL
       - name: make


### PR DESCRIPTION
On 29th of April, git.io will stop redirecting.

The github workflows in this project use the git.io shortener. I've
changed those to use the original addresses to prevent the workflows
from starting failing.

Ref: https://github.blog/changelog/2022-04-25-git-io-deprecation/