### PR TITLE
avoid failing when printing diagnostic info comparing partial overloaded objects

### DIFF
--- a/lib/Test/Builder.pm
+++ b/lib/Test/Builder.pm
@@ -1002,15 +1002,7 @@ END
             $self->_is_diag( $got, $type, $expect );
         }
         elsif( $type =~ /^(ne|!=)$/ ) {
-            no warnings;
-            my $eq = ($got eq $expect || $got == $expect)
-                && (
-                    (defined($got) xor defined($expect))
-                 || (length($got)  !=  length($expect))
-                );
-            use warnings;
-
-            if ($eq) {
+            if (defined($got) xor defined($expect)) {
                 $self->_cmp_diag( $got, $type, $expect );
             }
             else {

--- a/t/Legacy/cmp_ok.t
+++ b/t/Legacy/cmp_ok.t
@@ -60,6 +60,7 @@ Test::More->builder->no_ending(1);
 require MyOverload;
 my $cmp = Overloaded::Compare->new("foo", 42);
 my $ify = Overloaded::Ify->new("bar", 23);
+my $part = Overloaded::Partial->new('baz', 0);
 
 my @Tests = (
     [1, '==', 1],
@@ -73,6 +74,8 @@ my @Tests = (
     [$cmp, 'eq', "foo"],
     [$ify, 'eq', "bar"],
     [$ify, "==", 23],
+
+    [$part, '!=', 0, 'expected: anything else'],
 
     [1, "=", 0,  "= is not a valid comparison operator in cmp_ok()"],
     [1, "+=", 0, "+= is not a valid comparison operator in cmp_ok()"],

--- a/t/lib/MyOverload.pm
+++ b/t/lib/MyOverload.pm
@@ -33,4 +33,11 @@ use overload
     $_[0]->{num};
   };
 
+package Overloaded::Partial;
+
+our @ISA = qw(Overloaded);
+use overload
+  q{""} => sub { $_[0]->{string} },
+  q{!=} => sub { $_[0]->{num} != $_[1] };
+
 1;


### PR DESCRIPTION
Fixes #896.

It isn't obvious what the `eq`, `!=`, or `length` checks are meant to accomplish. The existing tests don't demonstrate any purpose for them.