### PR TITLE
Windows and macOS CI fixes

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -27,7 +27,7 @@ jobs:
       - name: perl -V
         run: perl -V
       - name: Install Dependencies
-        run: curl -sL https://github.com/Test-More/test-more/ | perl - install -g --show-build-log-on-failure
+        run: curl -sL https://raw.githubusercontent.com/skaji/cpm/master/cpm | perl - install -g --show-build-log-on-failure
       - name: perl Makefile.PL
         run: perl Makefile.PL
       - name: make

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -28,7 +28,7 @@ jobs:
       - name: perl -V
         run: perl -V
       - name: Install Dependencies
-        run: curl -sL https://github.com/Test-More/test-more/ | perl - install -g --show-build-log-on-failure
+        run: curl -sL https://raw.githubusercontent.com/skaji/cpm/master/cpm | perl - install -g --show-build-log-on-failure
       - name: perl Makefile.PL
         run: perl Makefile.PL
       - name: make

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Perl
         run: |
           choco install strawberryperl
-          echo "##[add-path]C:\strawberry\c\bin;C:\strawberry\perl\site\bin;C:\strawberry\perl\bin"
+          echo "C:\\strawberry\\c\\bin;C:\\strawberry\\perl\\site\\bin;C:\\strawberry\\perl\\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
       - name: perl -V
         run: perl -V
       - name: Install Dependencies


### PR DESCRIPTION
When removing the use of the git.io redirector, the wrong replacement
URL was used. Correct the URL to point to the cpm script.

The add-path action has been removed. Switch to using the $GITHUB_PATH
file.