### PR TITLE
Silence deprecation warning when testing smartmatch

### DIFF
--- a/t/Legacy/Regression/870-experimental-warnings.t
+++ b/t/Legacy/Regression/870-experimental-warnings.t
@@ -8,6 +8,7 @@ require Test::More;
 *cmp_ok = \&Test::More::cmp_ok;
 
 no warnings "experimental::smartmatch";
+no if !exists $warnings::Offsets{"experimental::smartmatch"}, warnings => 'deprecated';
 
 my $warnings = warnings { cmp_ok(1, "~~", 1) };
 


### PR DESCRIPTION
The smartmatch operator (along with `given` and `when`) is being deprecated in Perl 5.38.

When the `experimental::smartmatch` does not exists anymore, that means a deprecation warning will be produced instead. Silence it.