### PR TITLE
Fix deprecation warnings introduced in the Perl 5.37.{9,10} dev cycle

### DIFF
--- a/lib/Test/More.pm
+++ b/lib/Test/More.pm
@@ -394,8 +394,13 @@ different from some other value:
 
   isnt $obj, $clone, "clone() produces a different object";
 
-For those grammatical pedants out there, there's an C<isn't()>
-function which is an alias of C<isnt()>.
+Historically we supported an C<isn't()> function as an alias of
+C<isnt()>, however in Perl 5.37.9 support for the use of aprostrophe as
+a package separator was deprecated and by Perl 5.42.0 support for it
+will have been removed completely. Accordingly use of C<isn't()> is also
+deprecated, and will produce warnings when used unless 'deprecated'
+warnings are specifically disabled in the scope where it is used. You
+are strongly advised to migrate to using C<isnt()> instead.
 
 =cut
 
@@ -411,8 +416,24 @@ sub isnt ($$;$) {
     return $tb->isnt_eq(@_);
 }
 
-# make this available as isn't()
-*isn::t = \&isnt;
+# Historically it was possible to use apostrophes as a package
+# separator. make this available as isn't() for perl's that support it.
+# However in 5.37.9 the apostrophe as a package separator was
+# deprecated, so warn users of isn't() that they should use isnt()
+# instead. We assume that if they are calling isn::t() they are doing so
+# via isn't() as we have no way to be sure that they aren't spelling it
+# with a double colon. We only trigger the warning if deprecation
+# warnings are enabled, so the user can silence the warning if they
+# wish.
+sub isn::t {
+    if (warnings::enabled("deprecated")) {
+        _carp
+        "Use of apostrophe as package separator was deprecated in Perl 5.37.9,\n",
+        "and will be removed in Perl 5.42.0.  You should change code that uses\n",
+        "Test::More::isn't() to use Test::More::isnt() as a replacement";
+    }
+    goto &isnt;
+}
 
 =item B<like>
 

--- a/t/Legacy/More.t
+++ b/t/Legacy/More.t
@@ -8,7 +8,7 @@ BEGIN {
 }
 
 use lib 't/lib';
-use Test::More tests => 54;
+use Test::More tests => 57;
 
 # Make sure we don't mess with $@ or $!.  Test at bottom.
 my $Err   = "this should not be touched";
@@ -24,7 +24,24 @@ require_ok('Test::More');
 ok( 2 eq 2,             'two is two is two is two' );
 is(   "foo", "foo",       'foo is foo' );
 isnt( "foo", "bar",     'foo isnt bar');
-isn::t("foo", "bar",     'foo isn\'t bar');
+{
+    use warnings;
+    my $warning;
+    local $SIG{__WARN__}= sub { $warning = $_[0] };
+    isn::t("foo", "bar",     'foo isn\'t bar');
+    is($warning, "Use of apostrophe as package separator was deprecated in Perl 5.37.9,\n"
+               . "and will be removed in Perl 5.42.0.  You should change code that uses\n"
+               . "Test::More::isn't() to use Test::More::isnt() as a replacement"
+               . " at t/Legacy/More.t line 31\n",
+            "Got expected warning from isn::t() under use warnings");
+}
+{
+    no warnings "deprecated";
+    my $warning;
+    local $SIG{__WARN__}= sub { $warning = $_[0] };
+    isn::t("foo", "bar",     'foo isn\'t bar');
+    is($warning, undef, "No warnings from isn::t() under no warnings deprecated");
+}
 
 #'#
 like("fooble", '/^foo/',    'foo is like fooble');

--- a/t/Legacy/Regression/870-experimental-warnings.t
+++ b/t/Legacy/Regression/870-experimental-warnings.t
@@ -2,7 +2,10 @@ use strict;
 use warnings;
 use Test2::Tools::Tiny;
 
-BEGIN { skip_all "Only testing on 5.18+" if $] < 5.018 }
+BEGIN {
+    skip_all "Not testing before 5.18 or after 5.37.10"
+        if $] < 5.018 or $] >= 5.037010;
+}
 
 require Test::More;
 *cmp_ok = \&Test::More::cmp_ok;


### PR DESCRIPTION
Smartmatch and apostrophe as a package separator are deprecated. This fixes the tests and makes isn::t() warn when it is used. 

I did not version bump anything as I understand this is automated in Dist::Zilla based repos.