### PR TITLE
Guard %ENV access with exists() checks and some minor edge case bugs I found while doing so

### DIFF
--- a/lib/Test/Tester.pm
+++ b/lib/Test/Tester.pm
@@ -13,6 +13,7 @@ BEGIN
 use Test::Builder;
 use Test::Tester::CaptureRunner;
 use Test::Tester::Delegate;
+use Test2::Util qw(_env_get);
 
 require Exporter;
 
@@ -30,7 +31,7 @@ $Delegator->{Object} = $Test;
 
 my $runner = Test::Tester::CaptureRunner->new;
 
-my $want_space = $ENV{TESTTESTERSPACE};
+my $want_space = _env_get('TESTTESTERSPACE');
 
 sub show_space
 {
@@ -40,7 +41,7 @@ sub show_space
 my $colour = '';
 my $reset = '';
 
-if (my $want_colour = $ENV{TESTTESTERCOLOUR} || $ENV{TESTTESTERCOLOR})
+if (my $want_colour = _env_get('TESTTESTERCOLOUR') || _env_get('TESTTESTERCOLOR'))
 {
 	if (eval { require Term::ANSIColor; 1 })
 	{

--- a/lib/Test2/API.pm
+++ b/lib/Test2/API.pm
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 
 use Time::HiRes qw/time/;
-use Test2::Util qw/USE_THREADS/;
+use Test2::Util qw/USE_THREADS _env_get/;
 
 BEGIN {
     $ENV{TEST_ACTIVE} ||= 1;
@@ -287,7 +287,8 @@ sub test2_ipc_get_timeout     { $INST->ipc_timeout() }
 sub test2_ipc_enable_shm      { 0 }
 
 sub test2_formatter     {
-    if ($ENV{T2_FORMATTER} && $ENV{T2_FORMATTER} =~ m/^(\+)?(.*)$/) {
+    my $env_var = _env_get('T2_FORMATTER', '');
+    if ($env_var =~ m/^(\+)?(.+)$/) {
         my $formatter = $1 ? $2 : "Test2::Formatter::$2";
         my $file = pkg_to_file($formatter);
         require $file;

--- a/lib/Test2/API/Instance.pm
+++ b/lib/Test2/API/Instance.pm
@@ -163,10 +163,10 @@ sub _finalize {
 
     unless ($self->{+FORMATTER}) {
         my ($formatter, $source);
-        if ($ENV{T2_FORMATTER}) {
+        if (my $env_val = _env_get('T2_FORMATTER')) {
             $source = "set by the 'T2_FORMATTER' environment variable";
 
-            if ($ENV{T2_FORMATTER} =~ m/^(\+)?(.*)$/) {
+            if ($env_val =~ m/^(\+)?(.+)$/) {
                 $formatter = $1 ? $2 : "Test2::Formatter::$2"
             }
             else {
@@ -177,7 +177,8 @@ sub _finalize {
             ($formatter) = @{$self->{+FORMATTERS}};
             $source = "Most recently added";
         }
-        else {
+
+        if (!$formatter) {
             $formatter = 'Test2::Formatter::TAP';
             $source    = 'default formatter';
         }

--- a/lib/Test2/API/Instance.pm
+++ b/lib/Test2/API/Instance.pm
@@ -8,7 +8,7 @@ our @CARP_NOT = qw/Test2::API Test2::API::Instance Test2::IPC::Driver Test2::For
 use Carp qw/confess carp/;
 use Scalar::Util qw/reftype/;
 
-use Test2::Util qw/get_tid USE_THREADS CAN_FORK pkg_to_file try CAN_SIGSYS/;
+use Test2::Util qw/get_tid USE_THREADS CAN_FORK pkg_to_file try CAN_SIGSYS _env_get/;
 
 use Test2::EventFacet::Trace();
 use Test2::API::Stack();
@@ -104,7 +104,7 @@ sub post_preload_reset {
 
     $self->{+FINALIZED} = undef;
     $self->{+IPC}       = undef;
-    $self->{+IPC_DISABLED} = $ENV{T2_NO_IPC} ? 1 : 0;
+    $self->{+IPC_DISABLED} = _env_get('T2_NO_IPC') ? 1 : 0;
 
     $self->{+IPC_TIMEOUT} = DEFAULT_IPC_TIMEOUT() unless defined $self->{+IPC_TIMEOUT};
 
@@ -131,7 +131,7 @@ sub reset {
 
     $self->{+FINALIZED}    = undef;
     $self->{+IPC}          = undef;
-    $self->{+IPC_DISABLED} = $ENV{T2_NO_IPC} ? 1 : 0;
+    $self->{+IPC_DISABLED} = _env_get('T2_NO_IPC') ? 1 : 0;
 
     $self->{+IPC_TIMEOUT} = DEFAULT_IPC_TIMEOUT() unless defined $self->{+IPC_TIMEOUT};
 

--- a/lib/Test2/Event.pm
+++ b/lib/Test2/Event.pm
@@ -9,7 +9,7 @@ use Carp qw/croak/;
 
 use Test2::Util::HashBase qw/trace -amnesty uuid -_eid -hubs/;
 use Test2::Util::ExternalMeta qw/meta get_meta set_meta delete_meta/;
-use Test2::Util qw/pkg_to_file gen_uid/;
+use Test2::Util qw/pkg_to_file gen_uid _env_get/;
 
 use Test2::EventFacet::About();
 use Test2::EventFacet::Amnesty();
@@ -294,7 +294,7 @@ sub nested {
     my $self = shift;
 
     Carp::cluck("Use of Test2::Event->nested() is deprecated, use Test2::Event->trace->nested instead")
-        if $ENV{AUTHOR_TESTING};
+        if _env_get('AUTHOR_TESTING');
 
     if (my $hubs = $self->{+HUBS}) {
         return $hubs->[0]->{nested} if @$hubs;
@@ -308,7 +308,7 @@ sub in_subtest {
     my $self = shift;
 
     Carp::cluck("Use of Test2::Event->in_subtest() is deprecated, use Test2::Event->trace->hid instead")
-        if $ENV{AUTHOR_TESTING};
+        if _env_get('AUTHOR_TESTING');
 
     my $hubs = $self->{+HUBS};
     if ($hubs && @$hubs) {

--- a/lib/Test2/Formatter/TAP.pm
+++ b/lib/Test2/Formatter/TAP.pm
@@ -4,7 +4,7 @@ use warnings;
 
 our $VERSION = '1.302195';
 
-use Test2::Util qw/clone_io/;
+use Test2::Util qw/clone_io _env_get/;
 
 use Test2::Util::HashBase qw{
     no_numbers handles _encoding _last_fh
@@ -116,7 +116,7 @@ sub write {
         my $io = $handles->[$hid] or next;
 
         print $io "\n"
-            if $ENV{HARNESS_ACTIVE}
+            if _env_get('HARNESS_ACTIVE')
             && $hid == OUT_ERR
             && $self->{+_LAST_FH} != $io
             && $msg =~ m/^#\s*Failed( \(TODO\))? test /;
@@ -294,7 +294,7 @@ sub assert_tap {
         # In a verbose harness we indent the extra since they will appear
         # inside the subtest braces. This helps readability. In a non-verbose
         # harness we do not do this because it is less readable.
-        if ($ENV{HARNESS_IS_VERBOSE} || !$ENV{HARNESS_ACTIVE}) {
+        if (_env_get("HARNESS_IS_VERBOSE") || !_env_get("HARNESS_ACTIVE")) {
             $extra_indent = "    ";
             $extra_space = ' ';
         }

--- a/lib/Test2/Util.pm
+++ b/lib/Test2/Util.pm
@@ -36,11 +36,24 @@ our @EXPORT_OK = qw{
     try_sig_mask
 
     clone_io
+
+    _env_get
 };
 BEGIN { require Exporter; our @ISA = qw(Exporter) }
 
 BEGIN {
     *IS_WIN32 = ($^O eq 'MSWin32') ? sub() { 1 } : sub() { 0 };
+}
+
+# check for key existence before fetching from %ENV to avoid
+# locked hash issues. If it does not exist, or it does and the
+# value is undefined return $_[1] instead, thus allowing
+# a default value to be supplied if required.
+sub _env_get {
+    my ($key,$default) = @_;
+    my $got = exists($ENV{$key}) ? $ENV{$key} : undef;
+    $got = $default unless defined $got;
+    return $got;
 }
 
 sub _can_thread {


### PR DESCRIPTION
In  https://github.com/Perl/perl5/pull/20928 I discovered that if %ENV is locked while testing and a test fails then Test::More blows up horribly.  You can argue this issue several ways, including that it is a Hash::Util testing bug. But I think Test::More can harden itself pretty reasonably against this issue by simply checking for key existence before reading a key.  I did not attempt to deal with the places where there are *writes* to ENV, obviously that is going to end badly if %ENV is locked. But reading from a locked %ENV during testing is easy to guard against and obviously at least possible to happen since code doing so has been in perl core for a long time. :-) 

Related tickets:
https://github.com/Test-More/test-more/issues/907
https://github.com/Perl/perl5/issues/20929

Along the way I noticed a subtle error in the logic for parsing the T2_FORMATTER env var. If the string is set to "+" it would end up setting the formatter to the empty string. I also realized it was possible for the logic to not set it at all, and step past the defaulting logic in Test2::API::Instance. So I fixed it. Since part of this logic reads from the %ENV I dealt with both issues in the same commit. Hope that is ok.
