### PR TITLE
Fix #882

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,7 @@
 {{$NEXT}}
 
+    - Fix #882
+
 1.302194  2023-03-13 20:06:57-07:00 America/Los_Angeles
 
     - Fix failing test on 5.10

--- a/lib/Test2/API.pm
+++ b/lib/Test2/API.pm
@@ -380,8 +380,15 @@ sub context {
     # Catch an edge case where we try to get context after the root hub has
     # been garbage collected resulting in a stack that has a single undef
     # hub
-    if (!$hub && !exists($params{hub}) && @$stack) {
-        my $msg = Carp::longmess("Attempt to get Test2 context after testing has completed (did you attempt a testing event after done_testing?)");
+    if (!($hub && $hub->{hid}) && !exists($params{hub}) && @$stack) {
+        my $msg;
+
+        if ($hub && !$hub->{hid}) {
+            $msg = Carp::longmess("$hub has no hid! (did you attempt a testing event after done_testing?). You may be relying on a tool or plugin that was based off an old Test2 that did not require hids.");
+        }
+        else {
+            $msg = Carp::longmess("Attempt to get Test2 context after testing has completed (did you attempt a testing event after done_testing?)");
+        }
 
         # The error message is usually masked by the global destruction, so we have to print to STDER
         print STDERR $msg;


### PR DESCRIPTION
This will "fix" or more accurately address #882. Theoretically the situation should not occur at all. In practice when things are messy, or some poorly written tool messes with Test2::API::Stack or Test2::API::Hub then it can happen. In these cases catch it and provide an intentional error instead of a bunch of unhelpful warnings