### PR TITLE
is_deeply: fix handling of VSTRING and LVALUE refs

### DIFF
--- a/lib/Test/More.pm
+++ b/lib/Test/More.pm
@@ -1206,13 +1206,28 @@ sub _format_stack {
     return $out;
 }
 
+my %_types = (
+  (map +($_ => $_), qw(
+    Regexp
+    ARRAY
+    HASH
+    SCALAR
+    REF
+    GLOB
+    CODE
+  )),
+  'LVALUE'  => 'SCALAR',
+  'REF'     => 'SCALAR',
+  'VSTRING' => 'SCALAR',
+);
+
 sub _type {
     my $thing = shift;
 
     return '' if !ref $thing;
 
-    for my $type (qw(Regexp ARRAY HASH REF SCALAR GLOB CODE VSTRING)) {
-        return $type if UNIVERSAL::isa( $thing, $type );
+    for my $type (keys %_types) {
+        return $_types{$type} if UNIVERSAL::isa( $thing, $type );
     }
 
     return '';

--- a/t/Legacy/is_deeply_fail.t
+++ b/t/Legacy/is_deeply_fail.t
@@ -26,7 +26,7 @@ package main;
 
 
 my $TB = Test::Builder->create;
-$TB->plan(tests => 102);
+$TB->plan(tests => 110);
 
 # Utility testing functions.
 sub ok ($;$) {
@@ -427,4 +427,32 @@ ERR
     my $version2 = v1.2.4;
     ok !is_deeply( [\\$version1], [\\$version2], "version objects");
     is( $out, "not ok 42 - version objects\n" );
+}
+
+{
+    my $version1 = v1.2.3;
+    my $version2 = '' . v1.2.3;
+    ok is_deeply( [\$version1], [\$version2], "version objects");
+    is( $out, "ok 43 - version objects\n" );
+}
+
+{
+    my $version1 = v1.2.3;
+    my $version2 = v1.2.3;
+    ok !is_deeply( [$version1], [\$version2], "version objects");
+    is( $out, "not ok 44 - version objects\n" );
+}
+
+{
+    my $string = "abc";
+    my $string2 = "b";
+    ok is_deeply( [\substr($string, 1, 1)], [\$string2], "lvalue ref");
+    is( $out, "ok 45 - lvalue ref\n" );
+}
+
+{
+    my $string = "b";
+    my $string2 = "b";
+    ok !is_deeply( [\substr($string, 1, 1)], ["b"], "lvalue ref");
+    is( $out, "not ok 46 - lvalue ref\n" );
 }


### PR DESCRIPTION
VSTRING and LVALUE are possible return types from ref, but they are essentially special cases of SCALAR refs. As far as is_deeply is concerned, they should be treated as equivalent.

Update the _type function to normalize VSTRING and LVALUE into SCALAR, so that the deep checks properly treat them as equivalent.

This fixes errors from doing comparisons with LVALUE refs, as well as fixing VSTRINGs comparing equal to an equivalent normal SCALAR string.

Fixes #916