### PR TITLE
fix perl version check in regression test

### DIFF
--- a/t/Test2/regression/gh_16.t
+++ b/t/Test2/regression/gh_16.t
@@ -7,7 +7,7 @@ use warnings;
 # less likely to fail for an unrelated reason) and when I have AUTHOR_TESTING
 # set.
 BEGIN {
-    unless($ENV{AUTHOR_TESTING} || eval "no warnings 'portable'; require 5.20; 1") {
+    unless($ENV{AUTHOR_TESTING} || eval "no warnings 'portable'; require v5.20; 1") {
         print "1..0 # Skip Crazy test, only run on 5.20+, or when AUTHOR_TESTING is set\n";
         exit 0;
     }


### PR DESCRIPTION
"require 5.20" checks for perl v5.200