### PR TITLE
Remove an unused variable on Test2::API::Context

### DIFF
--- a/lib/Test2/API/Context.pm
+++ b/lib/Test2/API/Context.pm
@@ -436,7 +436,6 @@ sub note {
 sub diag {
     my $self = shift;
     my ($message) = @_;
-    my $hub = $self->{+HUB};
     $self->send_event(
         'Diag',
         message => $message,


### PR DESCRIPTION
`my $hub = $self->{+HUB};` not used in `sub diag`.