### PR TITLE
fix links to github repo and licenses

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -21,8 +21,8 @@ exclude_filename = README.md
 [TestRelease]
 
 [MetaResources]
-bugtracker.web  = http://github.com/Test-More/test-more/issues
-repository.url  = http://github.com/Test-More/test-more/
+bugtracker.web  = https://github.com/Test-More/test-more/issues
+repository.url  = https://github.com/Test-More/test-more/
 repository.type = git
 
 [OnlyCorePrereqs]

--- a/lib/Test/Builder.pm
+++ b/lib/Test/Builder.pm
@@ -2647,4 +2647,4 @@ Copyright 2002-2008 by chromatic E<lt>chromatic@wgz.orgE<gt> and
 This program is free software; you can redistribute it and/or
 modify it under the same terms as Perl itself.
 
-See F<http://www.perl.com/perl/misc/Artistic.html>
+See L<https://dev.perl.org/licenses/>

--- a/lib/Test/Builder/Formatter.pm
+++ b/lib/Test/Builder/Formatter.pm
@@ -77,7 +77,7 @@ This is what takes events and turns them into TAP.
 =head1 SOURCE
 
 The source code repository for Test2 can be found at
-F<http://github.com/Test-More/test-more/>.
+L<https://github.com/Test-More/test-more/>.
 
 =head1 MAINTAINERS
 
@@ -102,6 +102,6 @@ Copyright 2020 Chad Granum E<lt>exodist@cpan.orgE<gt>.
 This program is free software; you can redistribute it and/or
 modify it under the same terms as Perl itself.
 
-See F<http://dev.perl.org/licenses/>
+See L<https://dev.perl.org/licenses/>
 
 =cut

--- a/lib/Test/Builder/TodoDiag.pm
+++ b/lib/Test/Builder/TodoDiag.pm
@@ -38,7 +38,7 @@ You do not need to use this directly.
 =head1 SOURCE
 
 The source code repository for Test2 can be found at
-F<http://github.com/Test-More/test-more/>.
+L<https://github.com/Test-More/test-more/>.
 
 =head1 MAINTAINERS
 
@@ -63,6 +63,6 @@ Copyright 2020 Chad Granum E<lt>exodist@cpan.orgE<gt>.
 This program is free software; you can redistribute it and/or
 modify it under the same terms as Perl itself.
 
-See F<http://dev.perl.org/licenses/>
+See L<https://dev.perl.org/licenses/>
 
 =cut

--- a/lib/Test/FAQ.pod
+++ b/lib/Test/FAQ.pod
@@ -15,9 +15,9 @@ L<Test::Tutorial>
 
 =head2 Are there any modules for testing?
 
-A whole bunch.  Start with L<Test::Simple> then move onto Test::More.
+A whole bunch.  Start with L<Test::Simple>, then move on to L<Test::More>.
 
-Then go onto L<http://search.cpan.org> and search for "Test".
+Then go on to L<https://metacpan.org/> and search for "Test".
 
 =head2 Are there any modules for testing web pages/CGI programs?
 

--- a/lib/Test/FAQ.pod
+++ b/lib/Test/FAQ.pod
@@ -212,12 +212,12 @@ C<ok(...) || diag "...";>
 
 =head2 Why use an ok() function?
 
-On Tue, Aug 28, 2001 at 02:12:46PM +0100, Robin Houston wrote:
-> Michael Schwern wrote:
-> > Ah HA!  I've been wondering why nobody ever thinks to write a simple
-> > ok() function for their tests!  perlhack has bad testing advice.
-> 
-> Could you explain the advantage of having a "simple ok() function"?
+    On Tue, Aug 28, 2001 at 02:12:46PM +0100, Robin Houston wrote:
+    > Michael Schwern wrote:
+    > > Ah HA!  I've been wondering why nobody ever thinks to write a simple
+    > > ok() function for their tests!  perlhack has bad testing advice.
+    > 
+    > Could you explain the advantage of having a "simple ok() function"?
 
 Because writing:
 
@@ -230,9 +230,9 @@ first place.  It also looks like hell and obscures the real purpose.
 Besides, that will cause problems on VMS.
 
 
-> As somebody who has spent many painful hours debugging test failures,
-> I'm intimately familiar with the _disadvantages_. When you run the
-> test, you know that "test 113 failed". That's all you know, in general.
+    > As somebody who has spent many painful hours debugging test failures,
+    > I'm intimately familiar with the _disadvantages_. When you run the
+    > test, you know that "test 113 failed". That's all you know, in general.
 
 Second advantage is you can easily upgrade the C<ok()> function to fix
 this, either by slapping this line in:
@@ -333,16 +333,16 @@ The most useful functions in L<Test::More> are C<is()>, C<like()> and C<is_deepl
 
 =head2 How do I check for an infinite loop?
 
-On Mon, Mar 18, 2002 at 03:57:55AM -0500, Mark-Jason Dominus wrote:
-> 
-> Michael The Schwern <schwern@pobox.com> says:
-> > Use alarm and skip the test if $Config{d_alarm} is false (see
-> > t/op/alarm.t for an example).  If you think the infinite loop is due
-> > to a programming glitch, as opposed to a cross-platform issue, this
-> > will be enough.
-> 
-> Thanks very much!
-> 
+    On Mon, Mar 18, 2002 at 03:57:55AM -0500, Mark-Jason Dominus wrote:
+    > 
+    > Michael The Schwern <schwern@pobox.com> says:
+    > > Use alarm and skip the test if $Config{d_alarm} is false (see
+    > > t/op/alarm.t for an example).  If you think the infinite loop is due
+    > > to a programming glitch, as opposed to a cross-platform issue, this
+    > > will be enough.
+    > 
+    > Thanks very much!
+    > 
 
 =head2 How can I check that flock works?
 

--- a/lib/Test/More.pm
+++ b/lib/Test/More.pm
@@ -2020,13 +2020,13 @@ the perl-qa gang.
 
 =head1 BUGS
 
-See F<https://github.com/Test-More/test-more/issues> to report and view bugs.
+See L<https://github.com/Test-More/test-more/issues> to report and view bugs.
 
 
 =head1 SOURCE
 
 The source code repository for Test::More can be found at
-F<http://github.com/Test-More/test-more/>.
+L<https://github.com/Test-More/test-more/>.
 
 
 =head1 COPYRIGHT
@@ -2036,7 +2036,7 @@ Copyright 2001-2008 by Michael G Schwern E<lt>schwern@pobox.comE<gt>.
 This program is free software; you can redistribute it and/or
 modify it under the same terms as Perl itself.
 
-See F<http://www.perl.com/perl/misc/Artistic.html>
+See L<https://dev.perl.org/licenses/>
 
 =cut
 

--- a/lib/Test/Simple.pm
+++ b/lib/Test/Simple.pm
@@ -213,7 +213,7 @@ Copyright 2001-2008 by Michael G Schwern E<lt>schwern@pobox.comE<gt>.
 This program is free software; you can redistribute it and/or 
 modify it under the same terms as Perl itself.
 
-See F<http://www.perl.com/perl/misc/Artistic.html>
+See L<https://dev.perl.org/licenses/>
 
 =cut
 

--- a/lib/Test/Tester.pm
+++ b/lib/Test/Tester.pm
@@ -690,6 +690,6 @@ Schwern <schwern@pobox.com>.
 
 Under the same license as Perl itself
 
-See http://www.perl.com/perl/misc/Artistic.html
+See L<https://dev.perl.org/licenses/>
 
 =cut

--- a/lib/Test/Tester/Capture.pm
+++ b/lib/Test/Tester/Capture.pm
@@ -236,6 +236,6 @@ chunks removed by Fergal Daly <fergal@esatclear.ie>.
 
 Under the same license as Perl itself
 
-See http://www.perl.com/perl/misc/Artistic.html
+See L<https://dev.perl.org/licenses/>
 
 =cut

--- a/lib/Test/Tester/CaptureRunner.pm
+++ b/lib/Test/Tester/CaptureRunner.pm
@@ -74,6 +74,6 @@ Copyright 2003 by Fergal Daly <fergal@esatclear.ie>.
 
 Under the same license as Perl itself
 
-See http://www.perl.com/perl/misc/Artistic.html
+See L<https://dev.perl.org/licenses/>
 
 =cut

--- a/lib/Test/use/ok.pm
+++ b/lib/Test/use/ok.pm
@@ -55,10 +55,10 @@ L<Test::More>
 =head1 CC0 1.0 Universal
 
 To the extent possible under law, 唐鳳 has waived all copyright and related
-or neighboring rights to L<Test-use-ok>.
+or neighboring rights to L<Test::use::ok>.
 
 This work is published from Taiwan.
 
-L<http://creativecommons.org/publicdomain/zero/1.0>
+L<https://creativecommons.org/publicdomain/zero/1.0/>
 
 =cut

--- a/lib/Test2.pm
+++ b/lib/Test2.pm
@@ -183,7 +183,7 @@ emailing Chad Granum E<lt>exodist@cpan.orgE<gt>.
 =head1 SOURCE
 
 The source code repository for Test2 can be found at
-F<http://github.com/Test-More/test-more/>.
+L<https://github.com/Test-More/test-more/>.
 
 =head1 MAINTAINERS
 
@@ -208,6 +208,6 @@ Copyright 2020 Chad Granum E<lt>exodist@cpan.orgE<gt>.
 This program is free software; you can redistribute it and/or
 modify it under the same terms as Perl itself.
 
-See F<http://dev.perl.org/licenses/>
+See L<https://dev.perl.org/licenses/>
 
 =cut

--- a/lib/Test2/API/Breakage.pm
+++ b/lib/Test2/API/Breakage.pm
@@ -150,7 +150,7 @@ not tested or verified.
 =head1 SOURCE
 
 The source code repository for Test2 can be found at
-F<http://github.com/Test-More/test-more/>.
+L<https://github.com/Test-More/test-more/>.
 
 =head1 MAINTAINERS
 
@@ -175,6 +175,6 @@ Copyright 2020 Chad Granum E<lt>exodist@cpan.orgE<gt>.
 This program is free software; you can redistribute it and/or
 modify it under the same terms as Perl itself.
 
-See F<http://dev.perl.org/licenses/>
+See L<https://dev.perl.org/licenses/>
 
 =cut

--- a/lib/Test2/API/Context.pm
+++ b/lib/Test2/API/Context.pm
@@ -987,7 +987,7 @@ tools, plugins, and other extensions.
 =head1 SOURCE
 
 The source code repository for Test2 can be found at
-F<http://github.com/Test-More/test-more/>.
+L<https://github.com/Test-More/test-more/>.
 
 =head1 MAINTAINERS
 
@@ -1014,6 +1014,6 @@ Copyright 2020 Chad Granum E<lt>exodist@cpan.orgE<gt>.
 This program is free software; you can redistribute it and/or
 modify it under the same terms as Perl itself.
 
-See F<http://dev.perl.org/licenses/>
+See L<https://dev.perl.org/licenses/>
 
 =cut

--- a/lib/Test2/API/Instance.pm
+++ b/lib/Test2/API/Instance.pm
@@ -800,7 +800,7 @@ which case new strings will be passed in. These are purely informative, you can
 =head1 SOURCE
 
 The source code repository for Test2 can be found at
-F<http://github.com/Test-More/test-more/>.
+L<https://github.com/Test-More/test-more/>.
 
 =head1 MAINTAINERS
 
@@ -825,6 +825,6 @@ Copyright 2020 Chad Granum E<lt>exodist@cpan.orgE<gt>.
 This program is free software; you can redistribute it and/or
 modify it under the same terms as Perl itself.
 
-See F<http://dev.perl.org/licenses/>
+See L<https://dev.perl.org/licenses/>
 
 =cut

--- a/lib/Test2/API/InterceptResult.pm
+++ b/lib/Test2/API/InterceptResult.pm
@@ -604,7 +604,7 @@ C<error_messages()> returns.
 =head1 SOURCE
 
 The source code repository for Test2 can be found at
-F<http://github.com/Test-More/test-more/>.
+L<https://github.com/Test-More/test-more/>.
 
 =head1 MAINTAINERS
 
@@ -629,6 +629,6 @@ Copyright 2020 Chad Granum E<lt>exodist@cpan.orgE<gt>.
 This program is free software; you can redistribute it and/or
 modify it under the same terms as Perl itself.
 
-See F<http://dev.perl.org/licenses/>
+See L<https://dev.perl.org/licenses/>
 
 =cut

--- a/lib/Test2/API/InterceptResult/Event.pm
+++ b/lib/Test2/API/InterceptResult/Event.pm
@@ -1058,7 +1058,7 @@ TODO
 =head1 SOURCE
 
 The source code repository for Test2 can be found at
-F<http://github.com/Test-More/test-more/>.
+L<https://github.com/Test-More/test-more/>.
 
 =head1 MAINTAINERS
 
@@ -1083,6 +1083,6 @@ Copyright 2020 Chad Granum E<lt>exodist@cpan.orgE<gt>.
 This program is free software; you can redistribute it and/or
 modify it under the same terms as Perl itself.
 
-See F<http://dev.perl.org/licenses/>
+See L<https://dev.perl.org/licenses/>
 
 =cut

--- a/lib/Test2/API/InterceptResult/Hub.pm
+++ b/lib/Test2/API/InterceptResult/Hub.pm
@@ -36,7 +36,7 @@ Test2::API::InterceptResult::Hub - Hub used by InterceptResult.
 =head1 SOURCE
 
 The source code repository for Test2 can be found at
-F<http://github.com/Test-More/test-more/>.
+L<https://github.com/Test-More/test-more/>.
 
 =head1 MAINTAINERS
 
@@ -61,6 +61,6 @@ Copyright 2020 Chad Granum E<lt>exodist@cpan.orgE<gt>.
 This program is free software; you can redistribute it and/or
 modify it under the same terms as Perl itself.
 
-See F<http://dev.perl.org/licenses/>
+See L<https://dev.perl.org/licenses/>
 
 =cut

--- a/lib/Test2/API/InterceptResult/Squasher.pm
+++ b/lib/Test2/API/InterceptResult/Squasher.pm
@@ -166,7 +166,7 @@ Internal use only, please ignore.
 =head1 SOURCE
 
 The source code repository for Test2 can be found at
-F<http://github.com/Test-More/test-more/>.
+L<https://github.com/Test-More/test-more/>.
 
 =head1 MAINTAINERS
 
@@ -191,6 +191,6 @@ Copyright 2020 Chad Granum E<lt>exodist@cpan.orgE<gt>.
 This program is free software; you can redistribute it and/or
 modify it under the same terms as Perl itself.
 
-See F<http://dev.perl.org/licenses/>
+See L<https://dev.perl.org/licenses/>
 
 =cut

--- a/lib/Test2/API/Stack.pm
+++ b/lib/Test2/API/Stack.pm
@@ -196,7 +196,7 @@ match the hub you expect (passed in as an argument) it will throw an exception.
 =head1 SOURCE
 
 The source code repository for Test2 can be found at
-F<http://github.com/Test-More/test-more/>.
+L<https://github.com/Test-More/test-more/>.
 
 =head1 MAINTAINERS
 
@@ -221,6 +221,6 @@ Copyright 2020 Chad Granum E<lt>exodist@cpan.orgE<gt>.
 This program is free software; you can redistribute it and/or
 modify it under the same terms as Perl itself.
 
-See F<http://dev.perl.org/licenses/>
+See L<https://dev.perl.org/licenses/>
 
 =cut

--- a/lib/Test2/Event.pm
+++ b/lib/Test2/Event.pm
@@ -748,7 +748,7 @@ tools, plugins, and other extensions.
 =head1 SOURCE
 
 The source code repository for Test2 can be found at
-F<http://github.com/Test-More/test-more/>.
+L<https://github.com/Test-More/test-more/>.
 
 =head1 MAINTAINERS
 
@@ -773,6 +773,6 @@ Copyright 2020 Chad Granum E<lt>exodist@cpan.orgE<gt>.
 This program is free software; you can redistribute it and/or
 modify it under the same terms as Perl itself.
 
-See F<http://dev.perl.org/licenses/>
+See L<https://dev.perl.org/licenses/>
 
 =cut

--- a/lib/Test2/Event/Bail.pm
+++ b/lib/Test2/Event/Bail.pm
@@ -79,7 +79,7 @@ The reason for the bailout.
 =head1 SOURCE
 
 The source code repository for Test2 can be found at
-F<http://github.com/Test-More/test-more/>.
+L<https://github.com/Test-More/test-more/>.
 
 =head1 MAINTAINERS
 
@@ -104,6 +104,6 @@ Copyright 2020 Chad Granum E<lt>exodist@cpan.orgE<gt>.
 This program is free software; you can redistribute it and/or
 modify it under the same terms as Perl itself.
 
-See F<http://dev.perl.org/licenses/>
+See L<https://dev.perl.org/licenses/>
 
 =cut

--- a/lib/Test2/Event/Diag.pm
+++ b/lib/Test2/Event/Diag.pm
@@ -69,7 +69,7 @@ The message for the diag.
 =head1 SOURCE
 
 The source code repository for Test2 can be found at
-F<http://github.com/Test-More/test-more/>.
+L<https://github.com/Test-More/test-more/>.
 
 =head1 MAINTAINERS
 
@@ -94,6 +94,6 @@ Copyright 2020 Chad Granum E<lt>exodist@cpan.orgE<gt>.
 This program is free software; you can redistribute it and/or
 modify it under the same terms as Perl itself.
 
-See F<http://dev.perl.org/licenses/>
+See L<https://dev.perl.org/licenses/>
 
 =cut

--- a/lib/Test2/Event/Encoding.pm
+++ b/lib/Test2/Event/Encoding.pm
@@ -67,7 +67,7 @@ The encoding being specified.
 =head1 SOURCE
 
 The source code repository for Test2 can be found at
-F<http://github.com/Test-More/test-more/>.
+L<https://github.com/Test-More/test-more/>.
 
 =head1 MAINTAINERS
 
@@ -92,6 +92,6 @@ Copyright 2020 Chad Granum E<lt>exodist@cpan.orgE<gt>.
 This program is free software; you can redistribute it and/or
 modify it under the same terms as Perl itself.
 
-See F<http://dev.perl.org/licenses/>
+See L<https://dev.perl.org/licenses/>
 
 =cut

--- a/lib/Test2/Event/Exception.pm
+++ b/lib/Test2/Event/Exception.pm
@@ -83,7 +83,7 @@ Be aware that all exceptions are stringified during construction.
 =head1 SOURCE
 
 The source code repository for Test2 can be found at
-F<http://github.com/Test-More/test-more/>.
+L<https://github.com/Test-More/test-more/>.
 
 =head1 MAINTAINERS
 
@@ -108,6 +108,6 @@ Copyright 2020 Chad Granum E<lt>exodist@cpan.orgE<gt>.
 This program is free software; you can redistribute it and/or
 modify it under the same terms as Perl itself.
 
-See F<http://dev.perl.org/licenses/>
+See L<https://dev.perl.org/licenses/>
 
 =cut

--- a/lib/Test2/Event/Fail.pm
+++ b/lib/Test2/Event/Fail.pm
@@ -88,7 +88,7 @@ This is an optimal representation of a failed assertion.
 =head1 SOURCE
 
 The source code repository for Test2 can be found at
-F<http://github.com/Test-More/test-more/>.
+L<https://github.com/Test-More/test-more/>.
 
 =head1 MAINTAINERS
 
@@ -113,6 +113,6 @@ Copyright 2020 Chad Granum E<lt>exodist@cpan.orgE<gt>.
 This program is free software; you can redistribute it and/or
 modify it under the same terms as Perl itself.
 
-See F<http://dev.perl.org/licenses/>
+See L<https://dev.perl.org/licenses/>
 
 =cut

--- a/lib/Test2/Event/Generic.pm
+++ b/lib/Test2/Event/Generic.pm
@@ -250,7 +250,7 @@ completely. This must be set to a positive integer (0 or larger).
 =head1 SOURCE
 
 The source code repository for Test2 can be found at
-F<http://github.com/Test-More/test-more/>.
+L<https://github.com/Test-More/test-more/>.
 
 =head1 MAINTAINERS
 
@@ -275,6 +275,6 @@ Copyright 2020 Chad Granum E<lt>exodist@cpan.orgE<gt>.
 This program is free software; you can redistribute it and/or
 modify it under the same terms as Perl itself.
 
-See F<http://dev.perl.org/licenses/>
+See L<https://dev.perl.org/licenses/>
 
 =cut

--- a/lib/Test2/Event/Note.pm
+++ b/lib/Test2/Event/Note.pm
@@ -67,7 +67,7 @@ The message for the note.
 =head1 SOURCE
 
 The source code repository for Test2 can be found at
-F<http://github.com/Test-More/test-more/>.
+L<https://github.com/Test-More/test-more/>.
 
 =head1 MAINTAINERS
 
@@ -92,6 +92,6 @@ Copyright 2020 Chad Granum E<lt>exodist@cpan.orgE<gt>.
 This program is free software; you can redistribute it and/or
 modify it under the same terms as Perl itself.
 
-See F<http://dev.perl.org/licenses/>
+See L<https://dev.perl.org/licenses/>
 
 =cut

--- a/lib/Test2/Event/Ok.pm
+++ b/lib/Test2/Event/Ok.pm
@@ -139,7 +139,7 @@ taken into account.
 =head1 SOURCE
 
 The source code repository for Test2 can be found at
-F<http://github.com/Test-More/test-more/>.
+L<https://github.com/Test-More/test-more/>.
 
 =head1 MAINTAINERS
 
@@ -164,6 +164,6 @@ Copyright 2020 Chad Granum E<lt>exodist@cpan.orgE<gt>.
 This program is free software; you can redistribute it and/or
 modify it under the same terms as Perl itself.
 
-See F<http://dev.perl.org/licenses/>
+See L<https://dev.perl.org/licenses/>
 
 =cut

--- a/lib/Test2/Event/Pass.pm
+++ b/lib/Test2/Event/Pass.pm
@@ -84,7 +84,7 @@ This is an optimal representation of a passing assertion.
 =head1 SOURCE
 
 The source code repository for Test2 can be found at
-F<http://github.com/Test-More/test-more/>.
+L<https://github.com/Test-More/test-more/>.
 
 =head1 MAINTAINERS
 
@@ -109,6 +109,6 @@ Copyright 2020 Chad Granum E<lt>exodist@cpan.orgE<gt>.
 This program is free software; you can redistribute it and/or
 modify it under the same terms as Perl itself.
 
-See F<http://dev.perl.org/licenses/>
+See L<https://dev.perl.org/licenses/>
 
 =cut

--- a/lib/Test2/Event/Plan.pm
+++ b/lib/Test2/Event/Plan.pm
@@ -139,7 +139,7 @@ Get the reason for the directive.
 =head1 SOURCE
 
 The source code repository for Test2 can be found at
-F<http://github.com/Test-More/test-more/>.
+L<https://github.com/Test-More/test-more/>.
 
 =head1 MAINTAINERS
 
@@ -164,6 +164,6 @@ Copyright 2020 Chad Granum E<lt>exodist@cpan.orgE<gt>.
 This program is free software; you can redistribute it and/or
 modify it under the same terms as Perl itself.
 
-See F<http://dev.perl.org/licenses/>
+See L<https://dev.perl.org/licenses/>
 
 =cut

--- a/lib/Test2/Event/Skip.pm
+++ b/lib/Test2/Event/Skip.pm
@@ -97,7 +97,7 @@ reduced down to 1 or 0).
 =head1 SOURCE
 
 The source code repository for Test2 can be found at
-F<http://github.com/Test-More/test-more/>.
+L<https://github.com/Test-More/test-more/>.
 
 =head1 MAINTAINERS
 
@@ -122,6 +122,6 @@ Copyright 2020 Chad Granum E<lt>exodist@cpan.orgE<gt>.
 This program is free software; you can redistribute it and/or
 modify it under the same terms as Perl itself.
 
-See F<http://www.perl.com/perl/misc/Artistic.html>
+See L<https://dev.perl.org/licenses/>
 
 =cut

--- a/lib/Test2/Event/Subtest.pm
+++ b/lib/Test2/Event/Subtest.pm
@@ -135,7 +135,7 @@ is false it means all subevents render as they are produced.
 =head1 SOURCE
 
 The source code repository for Test2 can be found at
-F<http://github.com/Test-More/test-more/>.
+L<https://github.com/Test-More/test-more/>.
 
 =head1 MAINTAINERS
 
@@ -160,6 +160,6 @@ Copyright 2020 Chad Granum E<lt>exodist@cpan.orgE<gt>.
 This program is free software; you can redistribute it and/or
 modify it under the same terms as Perl itself.
 
-See F<http://dev.perl.org/licenses/>
+See L<https://dev.perl.org/licenses/>
 
 =cut

--- a/lib/Test2/Event/TAP/Version.pm
+++ b/lib/Test2/Event/TAP/Version.pm
@@ -71,7 +71,7 @@ The TAP version being parsed.
 =head1 SOURCE
 
 The source code repository for Test2 can be found at
-F<http://github.com/Test-More/test-more/>.
+L<https://github.com/Test-More/test-more/>.
 
 =head1 MAINTAINERS
 
@@ -96,6 +96,6 @@ Copyright 2020 Chad Granum E<lt>exodist@cpan.orgE<gt>.
 This program is free software; you can redistribute it and/or
 modify it under the same terms as Perl itself.
 
-See F<http://dev.perl.org/licenses/>
+See L<https://dev.perl.org/licenses/>
 
 =cut

--- a/lib/Test2/Event/V2.pm
+++ b/lib/Test2/Event/V2.pm
@@ -209,7 +209,7 @@ tools, plugins, and other extensions.
 =head1 SOURCE
 
 The source code repository for Test2 can be found at
-F<http://github.com/Test-More/test-more/>.
+L<https://github.com/Test-More/test-more/>.
 
 =head1 MAINTAINERS
 
@@ -234,6 +234,6 @@ Copyright 2020 Chad Granum E<lt>exodist@cpan.orgE<gt>.
 This program is free software; you can redistribute it and/or
 modify it under the same terms as Perl itself.
 
-See F<http://dev.perl.org/licenses/>
+See L<https://dev.perl.org/licenses/>
 
 =cut

--- a/lib/Test2/Event/Waiting.pm
+++ b/lib/Test2/Event/Waiting.pm
@@ -46,7 +46,7 @@ when the main process/thread is ready to end.
 =head1 SOURCE
 
 The source code repository for Test2 can be found at
-F<http://github.com/Test-More/test-more/>.
+L<https://github.com/Test-More/test-more/>.
 
 =head1 MAINTAINERS
 
@@ -71,6 +71,6 @@ Copyright 2020 Chad Granum E<lt>exodist@cpan.orgE<gt>.
 This program is free software; you can redistribute it and/or
 modify it under the same terms as Perl itself.
 
-See F<http://dev.perl.org/licenses/>
+See L<https://dev.perl.org/licenses/>
 
 =cut

--- a/lib/Test2/EventFacet.pm
+++ b/lib/Test2/EventFacet.pm
@@ -63,7 +63,7 @@ as arguments.
 =head1 SOURCE
 
 The source code repository for Test2 can be found at
-F<http://github.com/Test-More/test-more/>.
+L<https://github.com/Test-More/test-more/>.
 
 =head1 MAINTAINERS
 
@@ -88,6 +88,6 @@ Copyright 2020 Chad Granum E<lt>exodist@cpan.orgE<gt>.
 This program is free software; you can redistribute it and/or
 modify it under the same terms as Perl itself.
 
-See F<http://dev.perl.org/licenses/>
+See L<https://dev.perl.org/licenses/>
 
 =cut

--- a/lib/Test2/EventFacet/About.pm
+++ b/lib/Test2/EventFacet/About.pm
@@ -62,7 +62,7 @@ A unique (for the test job) identifier for the event.
 =head1 SOURCE
 
 The source code repository for Test2 can be found at
-F<http://github.com/Test-More/test-more/>.
+L<https://github.com/Test-More/test-more/>.
 
 =head1 MAINTAINERS
 
@@ -87,6 +87,6 @@ Copyright 2020 Chad Granum E<lt>exodist@cpan.orgE<gt>.
 This program is free software; you can redistribute it and/or
 modify it under the same terms as Perl itself.
 
-See F<http://dev.perl.org/licenses/>
+See L<https://dev.perl.org/licenses/>
 
 =cut

--- a/lib/Test2/EventFacet/Amnesty.pm
+++ b/lib/Test2/EventFacet/Amnesty.pm
@@ -61,7 +61,7 @@ marked todo.
 =head1 SOURCE
 
 The source code repository for Test2 can be found at
-F<http://github.com/Test-More/test-more/>.
+L<https://github.com/Test-More/test-more/>.
 
 =head1 MAINTAINERS
 
@@ -86,6 +86,6 @@ Copyright 2020 Chad Granum E<lt>exodist@cpan.orgE<gt>.
 This program is free software; you can redistribute it and/or
 modify it under the same terms as Perl itself.
 
-See F<http://dev.perl.org/licenses/>
+See L<https://dev.perl.org/licenses/>
 
 =cut

--- a/lib/Test2/EventFacet/Assert.pm
+++ b/lib/Test2/EventFacet/Assert.pm
@@ -63,7 +63,7 @@ spec only for harnesses.
 =head1 SOURCE
 
 The source code repository for Test2 can be found at
-F<http://github.com/Test-More/test-more/>.
+L<https://github.com/Test-More/test-more/>.
 
 =head1 MAINTAINERS
 
@@ -88,6 +88,6 @@ Copyright 2020 Chad Granum E<lt>exodist@cpan.orgE<gt>.
 This program is free software; you can redistribute it and/or
 modify it under the same terms as Perl itself.
 
-See F<http://dev.perl.org/licenses/>
+See L<https://dev.perl.org/licenses/>
 
 =cut

--- a/lib/Test2/EventFacet/Control.pm
+++ b/lib/Test2/EventFacet/Control.pm
@@ -77,7 +77,7 @@ phase is signaled.
 =head1 SOURCE
 
 The source code repository for Test2 can be found at
-F<http://github.com/Test-More/test-more/>.
+L<https://github.com/Test-More/test-more/>.
 
 =head1 MAINTAINERS
 
@@ -102,6 +102,6 @@ Copyright 2020 Chad Granum E<lt>exodist@cpan.orgE<gt>.
 This program is free software; you can redistribute it and/or
 modify it under the same terms as Perl itself.
 
-See F<http://dev.perl.org/licenses/>
+See L<https://dev.perl.org/licenses/>
 
 =cut

--- a/lib/Test2/EventFacet/Error.pm
+++ b/lib/Test2/EventFacet/Error.pm
@@ -63,7 +63,7 @@ pass/fail result.
 =head1 SOURCE
 
 The source code repository for Test2 can be found at
-F<http://github.com/Test-More/test-more/>.
+L<https://github.com/Test-More/test-more/>.
 
 =head1 MAINTAINERS
 
@@ -88,6 +88,6 @@ Copyright 2020 Chad Granum E<lt>exodist@cpan.orgE<gt>.
 This program is free software; you can redistribute it and/or
 modify it under the same terms as Perl itself.
 
-See F<http://dev.perl.org/licenses/>
+See L<https://dev.perl.org/licenses/>
 
 =cut

--- a/lib/Test2/EventFacet/Hub.pm
+++ b/lib/Test2/EventFacet/Hub.pm
@@ -79,7 +79,7 @@ parent (This should never be set when nested is C<0> or C<undef>).
 =head1 SOURCE
 
 The source code repository for Test2 can be found at
-F<http://github.com/Test-More/test-more/>.
+L<https://github.com/Test-More/test-more/>.
 
 =head1 MAINTAINERS
 
@@ -104,6 +104,6 @@ Copyright 2020 Chad Granum E<lt>exodist@cpan.orgE<gt>.
 This program is free software; you can redistribute it and/or
 modify it under the same terms as Perl itself.
 
-See F<http://dev.perl.org/licenses/>
+See L<https://dev.perl.org/licenses/>
 
 =cut

--- a/lib/Test2/EventFacet/Info.pm
+++ b/lib/Test2/EventFacet/Info.pm
@@ -102,7 +102,7 @@ not STDERR, but should show them even in non-verbose mode.
 =head1 SOURCE
 
 The source code repository for Test2 can be found at
-F<http://github.com/Test-More/test-more/>.
+L<https://github.com/Test-More/test-more/>.
 
 =head1 MAINTAINERS
 
@@ -127,6 +127,6 @@ Copyright 2020 Chad Granum E<lt>exodist@cpan.orgE<gt>.
 This program is free software; you can redistribute it and/or
 modify it under the same terms as Perl itself.
 
-See F<http://dev.perl.org/licenses/>
+See L<https://dev.perl.org/licenses/>
 
 =cut

--- a/lib/Test2/EventFacet/Info/Table.pm
+++ b/lib/Test2/EventFacet/Info/Table.pm
@@ -114,7 +114,7 @@ L<Test2::EventFacet::Info> structure.
 =head1 SOURCE
 
 The source code repository for Test2 can be found at
-F<http://github.com/Test-More/test-more/>.
+L<https://github.com/Test-More/test-more/>.
 
 =head1 MAINTAINERS
 
@@ -139,6 +139,6 @@ Copyright 2020 Chad Granum E<lt>exodist@cpan.orgE<gt>.
 This program is free software; you can redistribute it and/or
 modify it under the same terms as Perl itself.
 
-See F<http://dev.perl.org/licenses/>
+See L<https://dev.perl.org/licenses/>
 
 =cut

--- a/lib/Test2/EventFacet/Meta.pm
+++ b/lib/Test2/EventFacet/Meta.pm
@@ -74,7 +74,7 @@ to know what metadata may be added, so any is allowed.
 =head1 SOURCE
 
 The source code repository for Test2 can be found at
-F<http://github.com/Test-More/test-more/>.
+L<https://github.com/Test-More/test-more/>.
 
 =head1 MAINTAINERS
 
@@ -99,6 +99,6 @@ Copyright 2020 Chad Granum E<lt>exodist@cpan.orgE<gt>.
 This program is free software; you can redistribute it and/or
 modify it under the same terms as Perl itself.
 
-See F<http://dev.perl.org/licenses/>
+See L<https://dev.perl.org/licenses/>
 
 =cut

--- a/lib/Test2/EventFacet/Parent.pm
+++ b/lib/Test2/EventFacet/Parent.pm
@@ -68,7 +68,7 @@ them yet).
 =head1 SOURCE
 
 The source code repository for Test2 can be found at
-F<http://github.com/Test-More/test-more/>.
+L<https://github.com/Test-More/test-more/>.
 
 =head1 MAINTAINERS
 
@@ -93,6 +93,6 @@ Copyright 2020 Chad Granum E<lt>exodist@cpan.orgE<gt>.
 This program is free software; you can redistribute it and/or
 modify it under the same terms as Perl itself.
 
-See F<http://dev.perl.org/licenses/>
+See L<https://dev.perl.org/licenses/>
 
 =cut

--- a/lib/Test2/EventFacet/Plan.pm
+++ b/lib/Test2/EventFacet/Plan.pm
@@ -64,7 +64,7 @@ of your life, maybe a hermitage would suite you?
 =head1 SOURCE
 
 The source code repository for Test2 can be found at
-F<http://github.com/Test-More/test-more/>.
+L<https://github.com/Test-More/test-more/>.
 
 =head1 MAINTAINERS
 
@@ -89,6 +89,6 @@ Copyright 2020 Chad Granum E<lt>exodist@cpan.orgE<gt>.
 This program is free software; you can redistribute it and/or
 modify it under the same terms as Perl itself.
 
-See F<http://dev.perl.org/licenses/>
+See L<https://dev.perl.org/licenses/>
 
 =cut

--- a/lib/Test2/EventFacet/Render.pm
+++ b/lib/Test2/EventFacet/Render.pm
@@ -76,7 +76,7 @@ event.
 =head1 SOURCE
 
 The source code repository for Test2 can be found at
-F<http://github.com/Test-More/test-more/>.
+L<https://github.com/Test-More/test-more/>.
 
 =head1 MAINTAINERS
 
@@ -101,6 +101,6 @@ Copyright 2020 Chad Granum E<lt>exodist@cpan.orgE<gt>.
 This program is free software; you can redistribute it and/or
 modify it under the same terms as Perl itself.
 
-See F<http://dev.perl.org/licenses/>
+See L<https://dev.perl.org/licenses/>
 
 =cut

--- a/lib/Test2/EventFacet/Trace.pm
+++ b/lib/Test2/EventFacet/Trace.pm
@@ -277,7 +277,7 @@ number, and the cid.
 =head1 SOURCE
 
 The source code repository for Test2 can be found at
-F<http://github.com/Test-More/test-more/>.
+L<https://github.com/Test-More/test-more/>.
 
 =head1 MAINTAINERS
 
@@ -302,6 +302,6 @@ Copyright 2020 Chad Granum E<lt>exodist@cpan.orgE<gt>.
 This program is free software; you can redistribute it and/or
 modify it under the same terms as Perl itself.
 
-See F<http://dev.perl.org/licenses/>
+See L<https://dev.perl.org/licenses/>
 
 =cut

--- a/lib/Test2/Formatter.pm
+++ b/lib/Test2/Formatter.pm
@@ -128,7 +128,7 @@ they can do that.
 =head1 SOURCE
 
 The source code repository for Test2 can be found at
-F<http://github.com/Test-More/test-more/>.
+L<https://github.com/Test-More/test-more/>.
 
 =head1 MAINTAINERS
 
@@ -153,6 +153,6 @@ Copyright 2020 Chad Granum E<lt>exodist@cpan.orgE<gt>.
 This program is free software; you can redistribute it and/or
 modify it under the same terms as Perl itself.
 
-See F<http://dev.perl.org/licenses/>
+See L<https://dev.perl.org/licenses/>
 
 =cut

--- a/lib/Test2/Formatter/TAP.pm
+++ b/lib/Test2/Formatter/TAP.pm
@@ -496,7 +496,7 @@ Write an event to the console.
 =head1 SOURCE
 
 The source code repository for Test2 can be found at
-F<http://github.com/Test-More/test-more/>.
+L<https://github.com/Test-More/test-more/>.
 
 =head1 MAINTAINERS
 
@@ -523,6 +523,6 @@ Copyright 2020 Chad Granum E<lt>exodist@cpan.orgE<gt>.
 This program is free software; you can redistribute it and/or
 modify it under the same terms as Perl itself.
 
-See F<http://dev.perl.org/licenses/>
+See L<https://dev.perl.org/licenses/>
 
 =cut

--- a/lib/Test2/Hub.pm
+++ b/lib/Test2/Hub.pm
@@ -879,7 +879,7 @@ tools, plugins, and other extensions.
 =head1 SOURCE
 
 The source code repository for Test2 can be found at
-F<http://github.com/Test-More/test-more/>.
+L<https://github.com/Test-More/test-more/>.
 
 =head1 MAINTAINERS
 
@@ -904,6 +904,6 @@ Copyright 2020 Chad Granum E<lt>exodist@cpan.orgE<gt>.
 This program is free software; you can redistribute it and/or
 modify it under the same terms as Perl itself.
 
-See F<http://dev.perl.org/licenses/>
+See L<https://dev.perl.org/licenses/>
 
 =cut

--- a/lib/Test2/Hub/Interceptor.pm
+++ b/lib/Test2/Hub/Interceptor.pm
@@ -114,7 +114,7 @@ Test2::Hub::Interceptor - Hub used by interceptor to grab results.
 =head1 SOURCE
 
 The source code repository for Test2 can be found at
-F<http://github.com/Test-More/test-more/>.
+L<https://github.com/Test-More/test-more/>.
 
 =head1 MAINTAINERS
 
@@ -139,6 +139,6 @@ Copyright 2020 Chad Granum E<lt>exodist@cpan.orgE<gt>.
 This program is free software; you can redistribute it and/or
 modify it under the same terms as Perl itself.
 
-See F<http://dev.perl.org/licenses/>
+See L<https://dev.perl.org/licenses/>
 
 =cut

--- a/lib/Test2/Hub/Interceptor/Terminator.pm
+++ b/lib/Test2/Hub/Interceptor/Terminator.pm
@@ -21,7 +21,7 @@ Test2::Hub::Interceptor
 =head1 SOURCE
 
 The source code repository for Test2 can be found at
-F<http://github.com/Test-More/test-more/>.
+L<https://github.com/Test-More/test-more/>.
 
 =head1 MAINTAINERS
 
@@ -46,6 +46,6 @@ Copyright 2020 Chad Granum E<lt>exodist@cpan.orgE<gt>.
 This program is free software; you can redistribute it and/or
 modify it under the same terms as Perl itself.
 
-See F<http://dev.perl.org/licenses/>
+See L<https://dev.perl.org/licenses/>
 
 =cut

--- a/lib/Test2/Hub/Subtest.pm
+++ b/lib/Test2/Hub/Subtest.pm
@@ -106,7 +106,7 @@ to true B<you> are responsible for ensuring no additional events are generated.
 =head1 SOURCE
 
 The source code repository for Test2 can be found at
-F<http://github.com/Test-More/test-more/>.
+L<https://github.com/Test-More/test-more/>.
 
 =head1 MAINTAINERS
 
@@ -131,6 +131,6 @@ Copyright 2020 Chad Granum E<lt>exodist@cpan.orgE<gt>.
 This program is free software; you can redistribute it and/or
 modify it under the same terms as Perl itself.
 
-See F<http://dev.perl.org/licenses/>
+See L<https://dev.perl.org/licenses/>
 
 =cut

--- a/lib/Test2/IPC.pm
+++ b/lib/Test2/IPC.pm
@@ -130,7 +130,7 @@ Cull allows you to collect results from other processes or threads on demand.
 =head1 SOURCE
 
 The source code repository for Test2 can be found at
-F<http://github.com/Test-More/test-more/>.
+L<https://github.com/Test-More/test-more/>.
 
 =head1 MAINTAINERS
 
@@ -155,6 +155,6 @@ Copyright 2020 Chad Granum E<lt>exodist@cpan.orgE<gt>.
 This program is free software; you can redistribute it and/or
 modify it under the same terms as Perl itself.
 
-See F<http://dev.perl.org/licenses/>
+See L<https://dev.perl.org/licenses/>
 
 =cut

--- a/lib/Test2/IPC/Driver.pm
+++ b/lib/Test2/IPC/Driver.pm
@@ -257,7 +257,7 @@ can gracefully except it.
 =head1 SOURCE
 
 The source code repository for Test2 can be found at
-F<http://github.com/Test-More/test-more/>.
+L<https://github.com/Test-More/test-more/>.
 
 =head1 MAINTAINERS
 
@@ -282,6 +282,6 @@ Copyright 2020 Chad Granum E<lt>exodist@cpan.orgE<gt>.
 This program is free software; you can redistribute it and/or
 modify it under the same terms as Perl itself.
 
-See F<http://dev.perl.org/licenses/>
+See L<https://dev.perl.org/licenses/>
 
 =cut

--- a/lib/Test2/IPC/Driver/Files.pm
+++ b/lib/Test2/IPC/Driver/Files.pm
@@ -473,7 +473,7 @@ See L<Test2::IPC::Driver> for methods.
 =head1 SOURCE
 
 The source code repository for Test2 can be found at
-F<http://github.com/Test-More/test-more/>.
+L<https://github.com/Test-More/test-more/>.
 
 =head1 MAINTAINERS
 
@@ -498,6 +498,6 @@ Copyright 2020 Chad Granum E<lt>exodist@cpan.orgE<gt>.
 This program is free software; you can redistribute it and/or
 modify it under the same terms as Perl itself.
 
-See F<http://dev.perl.org/licenses/>
+See L<https://dev.perl.org/licenses/>
 
 =cut

--- a/lib/Test2/Tools/Tiny.pm
+++ b/lib/Test2/Tools/Tiny.pm
@@ -405,7 +405,7 @@ Result looks like this:
 =head1 SOURCE
 
 The source code repository for Test2 can be found at
-F<http://github.com/Test-More/test-more/>.
+L<https://github.com/Test-More/test-more/>.
 
 =head1 MAINTAINERS
 
@@ -430,6 +430,6 @@ Copyright 2020 Chad Granum E<lt>exodist@cpan.orgE<gt>.
 This program is free software; you can redistribute it and/or
 modify it under the same terms as Perl itself.
 
-See F<http://dev.perl.org/licenses/>
+See L<https://dev.perl.org/licenses/>
 
 =cut

--- a/lib/Test2/Transition.pod
+++ b/lib/Test2/Transition.pod
@@ -299,7 +299,7 @@ Still broken as of version: 0.05
 
 =item Test::Pretty
 
-See https://github.com/tokuhirom/Test-Pretty/issues/25
+See L<https://github.com/tokuhirom/Test-Pretty/issues/25>
 
 The author admits the module is crazy, and he is awaiting a stable release of
 something new (Test2) to completely rewrite it in a sane way.
@@ -490,7 +490,7 @@ only for review.
 =head1 SOURCE
 
 The source code repository for Test2 can be found at
-F<http://github.com/Test-More/test-more/>.
+L<https://github.com/Test-More/test-more/>.
 
 =head1 MAINTAINER
 
@@ -507,6 +507,6 @@ Copyright 2020 Chad Granum E<lt>exodist@cpan.orgE<gt>.
 This program is free software; you can redistribute it and/or
 modify it under the same terms as Perl itself.
 
-See F<http://www.perl.com/perl/misc/Artistic.html>
+See L<https://dev.perl.org/licenses/>
 
 =cut

--- a/lib/Test2/Util.pm
+++ b/lib/Test2/Util.pm
@@ -417,7 +417,7 @@ Devel::Cover is loaded before the check is first run.
 =head1 SOURCE
 
 The source code repository for Test2 can be found at
-F<http://github.com/Test-More/test-more/>.
+L<https://github.com/Test-More/test-more/>.
 
 =head1 MAINTAINERS
 
@@ -444,6 +444,6 @@ Copyright 2020 Chad Granum E<lt>exodist@cpan.orgE<gt>.
 This program is free software; you can redistribute it and/or
 modify it under the same terms as Perl itself.
 
-See F<http://dev.perl.org/licenses/>
+See L<https://dev.perl.org/licenses/>
 
 =cut

--- a/lib/Test2/Util/ExternalMeta.pm
+++ b/lib/Test2/Util/ExternalMeta.pm
@@ -152,7 +152,7 @@ key, but this package will not stringify it for you.
 =head1 SOURCE
 
 The source code repository for Test2 can be found at
-F<http://github.com/Test-More/test-more/>.
+L<https://github.com/Test-More/test-more/>.
 
 =head1 MAINTAINERS
 
@@ -177,6 +177,6 @@ Copyright 2020 Chad Granum E<lt>exodist@cpan.orgE<gt>.
 This program is free software; you can redistribute it and/or
 modify it under the same terms as Perl itself.
 
-See F<http://dev.perl.org/licenses/>
+See L<https://dev.perl.org/licenses/>
 
 =cut

--- a/lib/Test2/Util/Facets2Legacy.pm
+++ b/lib/Test2/Util/Facets2Legacy.pm
@@ -269,7 +269,7 @@ detected and an event is used as the argument.
 =head1 SOURCE
 
 The source code repository for Test2 can be found at
-F<http://github.com/Test-More/test-more/>.
+L<https://github.com/Test-More/test-more/>.
 
 =head1 MAINTAINERS
 
@@ -294,6 +294,6 @@ Copyright 2020 Chad Granum E<lt>exodist@cpan.orgE<gt>.
 This program is free software; you can redistribute it and/or
 modify it under the same terms as Perl itself.
 
-See F<http://dev.perl.org/licenses/>
+See L<https://dev.perl.org/licenses/>
 
 =cut

--- a/lib/Test2/Util/HashBase.pm
+++ b/lib/Test2/Util/HashBase.pm
@@ -443,7 +443,7 @@ determine the attribute to which each value will be paired.
 =head1 SOURCE
 
 The source code repository for HashBase can be found at
-F<http://github.com/Test-More/HashBase/>.
+L<https://github.com/Test-More/HashBase/>.
 
 =head1 MAINTAINERS
 
@@ -468,6 +468,6 @@ Copyright 2017 Chad Granum E<lt>exodist@cpan.orgE<gt>.
 This program is free software; you can redistribute it and/or
 modify it under the same terms as Perl itself.
 
-See F<http://dev.perl.org/licenses/>
+See L<https://dev.perl.org/licenses/>
 
 =cut

--- a/lib/Test2/Util/Trace.pm
+++ b/lib/Test2/Util/Trace.pm
@@ -28,7 +28,7 @@ L<Test2::EventFacet::Trace>.
 =head1 SOURCE
 
 The source code repository for Test2 can be found at
-F<http://github.com/Test-More/test-more/>.
+L<https://github.com/Test-More/test-more/>.
 
 =head1 MAINTAINERS
 
@@ -53,6 +53,6 @@ Copyright 2020 Chad Granum E<lt>exodist@cpan.orgE<gt>.
 This program is free software; you can redistribute it and/or
 modify it under the same terms as Perl itself.
 
-See F<http://dev.perl.org/licenses/>
+See L<https://dev.perl.org/licenses/>
 
 =cut

--- a/lib/ok.pm
+++ b/lib/ok.pm
@@ -40,10 +40,10 @@ Please see L<Test::use::ok> for the full description.
 =head1 CC0 1.0 Universal
 
 To the extent possible under law, 唐鳳 has waived all copyright and related
-or neighboring rights to L<Test-use-ok>.
+or neighboring rights to L<Test::use::ok>.
 
 This work is published from Taiwan.
 
-L<http://creativecommons.org/publicdomain/zero/1.0>
+L<https://creativecommons.org/publicdomain/zero/1.0/>
 
 =cut


### PR DESCRIPTION
... in all modules except for Test::Builder::IO::Scalar, which was
imported wholesale and contains bad POD upstream.

- POD links use L< >, not F< > (that's for files)
- add some L< > to previously un-marked-up URLs
- github, dev.perl.org, and creativecommons.org prefer https to http, so
  use that (saves a redirect)
- the correct link target for "the same terms as Perl itself" is the
  GPL/Artistic dual license overview page, not just the Artistic License
