### PR TITLE
Test::More skip() allows test name

### DIFF
--- a/lib/Test/More.pm
+++ b/lib/Test/More.pm
@@ -1382,7 +1382,7 @@ use TODO.  Read on.
 
 ## no critic (Subroutines::RequireFinalReturn)
 sub skip {
-    my( $why, $how_many ) = @_;
+    my( $why, $how_many, $name ) = @_;
     my $tb = Test::More->builder;
 
     # If the plan is set, and is static, then skip needs a count. If the plan
@@ -1402,7 +1402,7 @@ sub skip {
     }
 
     for( 1 .. $how_many ) {
-        $tb->skip($why);
+        $tb->skip($why, $name);
     }
 
     no warnings 'exiting';


### PR DESCRIPTION
Allow to specify which test name got skipped. This can be the exact name of a test when skipping only 1 test or a hint about which group of multiple tests is skippped.

That allows to provide a hint in the printed TAP about the skipped test, especially when the skip reason is too generic or re-used multiple times.

The name is just passed through to the test builder which takes care of handling it, in particular potential undefined values, which is important for backwards compatibility.