### PR TITLE
Test2::Hub - fix remove_context_{aquire,init,release} logic

### DIFF
--- a/lib/Test2/Hub.pm
+++ b/lib/Test2/Hub.pm
@@ -233,8 +233,8 @@ sub add_context_acquire {
 *remove_context_aquire = \&remove_context_acquire;
 sub remove_context_acquire {
     my $self = shift;
-    my %subs = map {$_ => $_} @_;
-    @{$self->{+_CONTEXT_ACQUIRE}} = grep { !$subs{$_} == $_ } @{$self->{+_CONTEXT_ACQUIRE}};
+    my %subs = map {$_ => 1} @_;
+    @{$self->{+_CONTEXT_ACQUIRE}} = grep { !$subs{$_} } @{$self->{+_CONTEXT_ACQUIRE}};
 }
 
 sub add_context_init {
@@ -251,8 +251,8 @@ sub add_context_init {
 
 sub remove_context_init {
     my $self = shift;
-    my %subs = map {$_ => $_} @_;
-    @{$self->{+_CONTEXT_INIT}} = grep { !$subs{$_} == $_ } @{$self->{+_CONTEXT_INIT}};
+    my %subs = map {$_ => 1} @_;
+    @{$self->{+_CONTEXT_INIT}} = grep { !$subs{$_} } @{$self->{+_CONTEXT_INIT}};
 }
 
 sub add_context_release {
@@ -269,8 +269,8 @@ sub add_context_release {
 
 sub remove_context_release {
     my $self = shift;
-    my %subs = map {$_ => $_} @_;
-    @{$self->{+_CONTEXT_RELEASE}} = grep { !$subs{$_} == $_ } @{$self->{+_CONTEXT_RELEASE}};
+    my %subs = map {$_ => 1} @_;
+    @{$self->{+_CONTEXT_RELEASE}} = grep { !$subs{$_} } @{$self->{+_CONTEXT_RELEASE}};
 }
 
 sub send {


### PR DESCRIPTION
As far as I can tell, the intended logic is:

 1. Build a set from passed-in arguments, represented as a hash.
 2. Keep only context handlers that are not elements of the set (i.e. not keys of the hash).

However, what the code actually did was to compare the result of `!` (which is a boolean, numerically 0 or 1) to a coderef, which is always false. In other words, the remove_context_* methods would ignore their arguments and always remove everything.