### PR TITLE
fix string comparisons with $] to use numeric comparison instead

### DIFF
--- a/lib/Test2/API.pm
+++ b/lib/Test2/API.pm
@@ -74,7 +74,7 @@ sub CLONE {
 
 BEGIN {
     no warnings 'once';
-    if($] ge '5.014' || $ENV{T2_CHECK_DEPTH} || $Test2::API::DO_DEPTH_CHECK) {
+    if("$]" >= 5.014 || $ENV{T2_CHECK_DEPTH} || $Test2::API::DO_DEPTH_CHECK) {
         *DO_DEPTH_CHECK = sub() { 1 };
     }
     else {

--- a/lib/Test2/Formatter/TAP.pm
+++ b/lib/Test2/Formatter/TAP.pm
@@ -66,7 +66,7 @@ sub _open_handles {
 sub encoding {
     my $self = shift;
 
-    if ($] ge "5.007003" and @_) {
+    if ("$]" >= 5.007003 and @_) {
         my ($enc) = @_;
         my $handles = $self->{+HANDLES};
 

--- a/lib/Test2/Tools/Tiny.pm
+++ b/lib/Test2/Tools/Tiny.pm
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 
 BEGIN {
-    if ($] lt "5.008") {
+    if ("$]" < 5.008) {
         require Test::Builder::IO::Scalar;
     }
 }
@@ -260,7 +260,7 @@ sub capture(&) {
 
         ($ok, $e) = try {
           # Scalar refs as filehandles were added in 5.8.
-          if ($] ge "5.008") {
+          if ("$]" >= 5.008) {
             open($out_fh, '>', \$out) or die "Failed to open a temporary STDOUT: $!";
             open($err_fh, '>', \$err) or die "Failed to open a temporary STDERR: $!";
           }

--- a/t/HashBase.t
+++ b/t/HashBase.t
@@ -84,7 +84,7 @@ is($pkg->do_it, 'const', "worked as expected");
 }
 ok(!$pkg->FOO, "overrode const sub");
 {
-local $TODO = "known to fail on $]" if $] le "5.006002";
+local $TODO = "known to fail on $]" if "$]" <= 5.006002;
 is($pkg->do_it, 'const', "worked as expected, const was constant");
 }
 

--- a/t/Legacy/Regression/736_use_ok.t
+++ b/t/Legacy/Regression/736_use_ok.t
@@ -19,7 +19,7 @@ sub capture(&) {
 }
 
 {
-local $TODO = "known to fail on $]" if $] le "5.006002";
+local $TODO = "known to fail on $]" if "$]" <= 5.006002;
 my $file = __FILE__;
 my $line = __LINE__ + 4;
 like(

--- a/t/Legacy/overload_threads.t
+++ b/t/Legacy/overload_threads.t
@@ -20,7 +20,7 @@ BEGIN {
 
 use Test::More;
 
-plan skip_all => "known to crash on $]" if $] le "5.006002";
+plan skip_all => "known to crash on $]" if "$]" <= 5.006002;
 
 plan tests => 5;
 

--- a/t/Legacy_And_Test2/preload_diag_note.t
+++ b/t/Legacy_And_Test2/preload_diag_note.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 
-if ($] lt "5.008") {
+if ("$]" < 5.008) {
     print "1..0 # SKIP Test cannot run on perls below 5.8.0\n";
     exit 0;
 }

--- a/t/Test2/behavior/init_croak.t
+++ b/t/Test2/behavior/init_croak.t
@@ -14,7 +14,7 @@ BEGIN {
     }
 }
 
-skip_all("known to fail on $]") if $] le "5.006002";
+skip_all("known to fail on $]") if "$]" <= 5.006002;
 
 $@ = "";
 my ($file, $line) = (__FILE__, __LINE__ + 1);

--- a/t/Test2/behavior/nested_context_exception.t
+++ b/t/Test2/behavior/nested_context_exception.t
@@ -5,7 +5,7 @@ use Test2::Tools::Tiny;
 
 use Test2::API qw/context/;
 
-skip_all("known to fail on $]") if $] le "5.006002";
+skip_all("known to fail on $]") if "$]" <= 5.006002;
 
 sub outer {
     my $code = shift;

--- a/t/Test2/modules/API.t
+++ b/t/Test2/modules/API.t
@@ -114,7 +114,7 @@ like(
     "got warning about adding driver too late"
 );
 };
-if ($] le "5.006002") {
+if ("$]" <= 5.006002) {
     todo("TODO known to fail on $]", $sub1);
 } else {
     $sub1->();

--- a/t/Test2/modules/API/Breakage.t
+++ b/t/Test2/modules/API/Breakage.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 
-if ($] lt "5.008") {
+if ("$]" < 5.008) {
     print "1..0 # SKIP Test cannot run on perls below 5.8.0 because local doesn't work on hash keys.\n";
     exit 0;
 }

--- a/t/Test2/modules/API/Instance.t
+++ b/t/Test2/modules/API/Instance.t
@@ -211,7 +211,7 @@ if (CAN_REALLY_FORK) {
     like($warnings[0], qr/Process .* did not exit cleanly \(wstat: \S+, exit: 0, sig: 15\)/, "Warn about exit");
 }
 
-if (CAN_THREAD && $] ge '5.010') {
+if (CAN_THREAD && "$]" >= 5.010) {
     require threads;
     my $one = $CLASS->new;
 
@@ -297,7 +297,7 @@ if (CAN_THREAD && $] ge '5.010') {
 }
 
 SKIP: {
-    last SKIP if $] lt "5.008";
+    last SKIP if "$]" < 5.008;
     my $one = $CLASS->new;
     my $stderr = "";
     {
@@ -326,7 +326,7 @@ This is not a supported configuration, you will have problems.
 }
 
 SKIP: {
-    last SKIP if $] lt "5.008";
+    last SKIP if "$]" < 5.008;
     require Test2::API::Breakage;
     no warnings qw/redefine once/;
     my $ran = 0;

--- a/t/Test2/modules/Hub.t
+++ b/t/Test2/modules/Hub.t
@@ -141,7 +141,7 @@ tests IPC => sub {
         }
     }
 
-    if (CAN_THREAD && $] ge '5.010') {
+    if (CAN_THREAD && "$]" >= 5.010) {
         require threads;
         my $thr = threads->new(sub { $do_send->() });
         $thr->join;

--- a/t/Test2/modules/IPC/Driver.t
+++ b/t/Test2/modules/IPC/Driver.t
@@ -26,7 +26,7 @@ for my $meth (qw/send cull add_hub drop_hub waiting is_viable/) {
 }
 
 SKIP: {
-    last SKIP if $] lt "5.008";
+    last SKIP if "$]" < 5.008;
 tests abort => sub {
     my $one = Test2::IPC::Driver->new(no_fatal => 1);
     my ($err, $out) = ("", "");

--- a/t/Test2/modules/IPC/Driver/Files.t
+++ b/t/Test2/modules/IPC/Driver/Files.t
@@ -6,7 +6,7 @@ use List::Util qw/shuffle/;
 use strict;
 use warnings;
 
-if ($] lt "5.008") {
+if ("$]" < 5.008) {
     print "1..0 # SKIP Test cannot run on perls below 5.8.0\n";
     exit 0;
 }

--- a/t/Test2/modules/Util.t
+++ b/t/Test2/modules/Util.t
@@ -34,7 +34,7 @@ use Test2::Util qw/
 /;
 
 BEGIN {
-    if ($] lt "5.008") {
+    if ("$]" < 5.008) {
         require Test::Builder::IO::Scalar;
     }
 }
@@ -83,7 +83,7 @@ close($io);
 
 my $fh;
 my $out = '';
-if ($] ge "5.008") {
+if ("$]" >= 5.008) {
     open($fh, '>', \$out) or die "Could not open filehandle";
 } else {
     $fh = Test::Builder::IO::Scalar->new(\$out) or die "Could not open filehandle";

--- a/t/Test2/regression/ipc_files_abort_exit.t
+++ b/t/Test2/regression/ipc_files_abort_exit.t
@@ -6,7 +6,7 @@ use Test2::Util qw/CAN_REALLY_FORK/;
 BEGIN {
     skip_all "Set AUTHOR_TESTING to run this test" unless $ENV{AUTHOR_TESTING};
     skip_all "System cannot fork" unless CAN_REALLY_FORK;
-    skip_all "known to fail on $]" if $] le "5.006002";
+    skip_all "known to fail on $]" if "$]" <= 5.006002;
 }
 
 use IPC::Open3 qw/open3/;

--- a/t/modules/Require/Perl.t
+++ b/t/modules/Require/Perl.t
@@ -1,6 +1,6 @@
 use Test2::Bundle::Extended -target => 'Test2::Require::Perl';
 
 is($CLASS->skip('v5.6'), undef, "will not skip");
-is($CLASS->skip('v10.10'), 'Perl v10.10.0 required', "will skip");
+is($CLASS->skip('v100.100'), 'Perl v100.100.0 required', "will skip"); # fix this before 2054
 
 done_testing;


### PR DESCRIPTION
The fix follows Zefram's suggestion from
https://www.nntp.perl.org/group/perl.perl5.porters/2012/05/msg186846.html

> On older perls, however, $] had a numeric value that was built up using
> floating-point arithmetic, such as 5+0.006+0.000002.  This would not
> necessarily match the conversion of the complete value from string form
> [perl #72210].  You can work around that by explicitly stringifying
> $] (which produces a correct string) and having *that* numify (to a
> correctly-converted floating point value) for comparison.  I cultivate
> the habit of always stringifying $] to work around this, regardless of
> the threshold where the bug was fixed.  So I'd write
>
>     use if "$]" >= 5.014, warnings => "non_unicode";

This ensures that the comparisons will still work when Perl's major version changes to anything greater than 9.