### PR TITLE
Simplify SKIP message when JSON::MaybeXS is not found

### DIFF
--- a/t/regression/247_check_ref_bool.t
+++ b/t/regression/247_check_ref_bool.t
@@ -1,7 +1,7 @@
 use Test2::V0;
 
 BEGIN {
-    skip_all "Need JSON::MaybeXS: $@" unless eval {
+    skip_all "Test needs JSON::MaybeXS" unless eval {
         require JSON::MaybeXS;
         JSON::MaybeXS->import(qw/decode_json/);
         1;


### PR DESCRIPTION
It's just a test file; we don't need a full dump of the user's `@INC`.