### PR TITLE
do not warn on false-but-blessed exceptions

### DIFF
--- a/lib/Test2/Tools/Exception.pm
+++ b/lib/Test2/Tools/Exception.pm
@@ -21,7 +21,7 @@ sub dies(&) {
 
     return undef if $ok;
 
-    unless ($err) {
+    unless (ref($err) or $err) {
         my $ctx = context();
         $ctx->alert("Got exception as expected, but exception is falsy (undef, '', or 0)...");
         $ctx->release;


### PR DESCRIPTION
While some consider this not best practice, blessed objects that overload to a false result are legitimate and should not be prevented.