### PR TITLE
don't use base

### DIFF
--- a/lib/Test2/Require/Threads.pm
+++ b/lib/Test2/Require/Threads.pm
@@ -2,7 +2,7 @@ package Test2::Require::Threads;
 use strict;
 use warnings;
 
-use base 'Test2::Require';
+BEGIN { require Test2::Require; our @ISA = qw(Test2::Require) }
 
 our $VERSION = '1.302209';
 

--- a/lib/Test2/Util/Facets2Legacy.pm
+++ b/lib/Test2/Util/Facets2Legacy.pm
@@ -7,7 +7,7 @@ our $VERSION = '1.302209';
 use Carp qw/croak confess/;
 use Scalar::Util qw/blessed/;
 
-use base 'Exporter';
+BEGIN { require Exporter; our @ISA = qw(Exporter) }
 our @EXPORT_OK = qw{
     causes_fail
     diagnostics


### PR DESCRIPTION
Instead of base.pm, load the module and assign to @INC. This matches how the rest of the codebase sets a parent class.