### PR TITLE
use PerlIO::get_layers without loading PerlIO.pm

### DIFF
--- a/lib/Test2/Util.pm
+++ b/lib/Test2/Util.pm
@@ -9,8 +9,7 @@ use Config qw/%Config/;
 use Carp qw/croak/;
 
 BEGIN {
-    local ($@, $!, $SIG{__DIE__});
-    *HAVE_PERLIO = eval { require PerlIO; PerlIO->VERSION(1.02); } ? sub() { 1 } : sub() { 0 };
+    *HAVE_PERLIO = defined &PerlIO::get_layers ? sub() { 1 } : sub() { 0 };
 }
 
 our @EXPORT_OK = qw{


### PR DESCRIPTION
PerlIO::get_layers is always available if PerlIO is available, without needing to load PerlIO.pm. Rather than trying to load it, we can just test for the existence of the function.