### PR TITLE
move try_sig_mask to separate file to avoid always loading POSIX

### DIFF
--- a/lib/Test2/IPC/Driver/Files.pm
+++ b/lib/Test2/IPC/Driver/Files.pm
@@ -14,7 +14,8 @@ use Storable();
 use File::Spec();
 use POSIX();
 
-use Test2::Util qw/try get_tid pkg_to_file IS_WIN32 ipc_separator do_rename do_unlink try_sig_mask/;
+use Test2::Util qw/try get_tid pkg_to_file IS_WIN32 ipc_separator do_rename do_unlink/;
+use Test2::Util::Sig qw/try_sig_mask/;
 use Test2::API qw/test2_ipc_set_pending/;
 
 sub is_viable { 1 }

--- a/lib/Test2/Util.pm
+++ b/lib/Test2/Util.pm
@@ -4,7 +4,6 @@ use warnings;
 
 our $VERSION = '1.302209';
 
-use POSIX();
 use Config qw/%Config/;
 use Carp qw/croak/;
 
@@ -248,30 +247,10 @@ BEGIN {
     }
 }
 
+#for backwards compatibility
 sub try_sig_mask(&) {
-    my $code = shift;
-
-    my ($old, $blocked);
-    unless(IS_WIN32) {
-        my $to_block = POSIX::SigSet->new(
-            POSIX::SIGINT(),
-            POSIX::SIGALRM(),
-            POSIX::SIGHUP(),
-            POSIX::SIGTERM(),
-            POSIX::SIGUSR1(),
-            POSIX::SIGUSR2(),
-        );
-        $old = POSIX::SigSet->new;
-        $blocked = POSIX::sigprocmask(POSIX::SIG_BLOCK(), $to_block, $old);
-        # Silently go on if we failed to log signals, not much we can do.
-    }
-
-    my ($ok, $err) = &try($code);
-
-    # If our block was successful we want to restore the old mask.
-    POSIX::sigprocmask(POSIX::SIG_SETMASK(), $old, POSIX::SigSet->new()) if defined $blocked;
-
-    return ($ok, $err);
+    require Test2::Util::Sig;
+    goto &Test2::Util::Sig::try_sig_mask;
 }
 
 1;
@@ -368,32 +347,6 @@ cross-platform when trying to rename files you recently altered.
 
 Unlink a file, this wraps C<unlink()> in a way that makes it more reliable
 cross-platform when trying to unlink files you recently altered.
-
-=item ($ok, $err) = try_sig_mask { ... }
-
-Complete an action with several signals masked, they will be unmasked at the
-end allowing any signals that were intercepted to get handled.
-
-This is primarily used when you need to make several actions atomic (against
-some signals anyway).
-
-Signals that are intercepted:
-
-=over 4
-
-=item SIGINT
-
-=item SIGALRM
-
-=item SIGHUP
-
-=item SIGTERM
-
-=item SIGUSR1
-
-=item SIGUSR2
-
-=back
 
 =back
 

--- a/lib/Test2/Util/Sig.pm
+++ b/lib/Test2/Util/Sig.pm
@@ -1,0 +1,123 @@
+package Test2::Util::Sig;
+use strict;
+use warnings;
+
+our $VERSION = '1.302205';
+
+use POSIX();
+use Test2::Util qw/try IS_WIN32/;
+
+our @EXPORT_OK = qw{
+    try_sig_mask
+};
+BEGIN { require Exporter; our @ISA = qw(Exporter) }
+
+sub try_sig_mask(&) {
+    my $code = shift;
+
+    my ($old, $blocked);
+    unless(IS_WIN32) {
+        my $to_block = POSIX::SigSet->new(
+            POSIX::SIGINT(),
+            POSIX::SIGALRM(),
+            POSIX::SIGHUP(),
+            POSIX::SIGTERM(),
+            POSIX::SIGUSR1(),
+            POSIX::SIGUSR2(),
+        );
+        $old = POSIX::SigSet->new;
+        $blocked = POSIX::sigprocmask(POSIX::SIG_BLOCK(), $to_block, $old);
+        # Silently go on if we failed to log signals, not much we can do.
+    }
+
+    my ($ok, $err) = &try($code);
+
+    # If our block was successful we want to restore the old mask.
+    POSIX::sigprocmask(POSIX::SIG_SETMASK(), $old, POSIX::SigSet->new()) if defined $blocked;
+
+    return ($ok, $err);
+}
+
+1;
+
+__END__
+
+=pod
+
+=encoding UTF-8
+
+=head1 NAME
+
+Test2::Util::Sig - Signal tools used by Test2 and friends.
+
+=head1 DESCRIPTION
+
+Collection of signal tools used by L<Test2> and friends.
+
+=head1 EXPORTS
+
+All exports are optional. You must specify subs to import.
+
+=over 4
+
+=item ($ok, $err) = try_sig_mask { ... }
+
+Complete an action with several signals masked, they will be unmasked at the
+end allowing any signals that were intercepted to get handled.
+
+This is primarily used when you need to make several actions atomic (against
+some signals anyway).
+
+Signals that are intercepted:
+
+=over 4
+
+=item SIGINT
+
+=item SIGALRM
+
+=item SIGHUP
+
+=item SIGTERM
+
+=item SIGUSR1
+
+=item SIGUSR2
+
+=back
+
+=back
+
+=head1 SOURCE
+
+The source code repository for Test2 can be found at
+L<https://github.com/Test-More/test-more/>.
+
+=head1 MAINTAINERS
+
+=over 4
+
+=item Chad Granum E<lt>exodist@cpan.orgE<gt>
+
+=back
+
+=head1 AUTHORS
+
+=over 4
+
+=item Chad Granum E<lt>exodist@cpan.orgE<gt>
+
+=item Kent Fredric E<lt>kentnl@cpan.orgE<gt>
+
+=back
+
+=head1 COPYRIGHT
+
+Copyright Chad Granum E<lt>exodist@cpan.orgE<gt>.
+
+This program is free software; you can redistribute it and/or
+modify it under the same terms as Perl itself.
+
+See L<https://dev.perl.org/licenses/>
+
+=cut


### PR DESCRIPTION
POSIX is an extra module to load which many test scripts don't need themselves. Test2::Util was loading it for the try_sig_mask function, but this is only used in one place for the IPC mechanism. If the script isn't loading Test2::IPC or running with threads, it is not needed.

Move the try_sig_mask function to a separate module, and use the new module in Test2::IPC::Driver::Files. For backwards compatibility, maintain a try_sig_mask function in Test2::Util, but have it load and call the function in the new module. A new module is used rather than just delay loading POSIX, because for something involving threads or forks, loading at process start is preferrable.