### PR TITLE
fix typo in Test2::Util::Trace docs

### DIFF
--- a/lib/Test2/Util/Trace.pm
+++ b/lib/Test2/Util/Trace.pm
@@ -18,7 +18,7 @@ __END__
 
 =head1 NAME
 
-Test2::Util::Trace - Legacy wrapper fro L<Test2::EventFacet::Trace>.
+Test2::Util::Trace - Legacy wrapper for L<Test2::EventFacet::Trace>.
 
 =head1 DESCRIPTION
 


### PR DESCRIPTION
I haven't added a Changes entry because the fix is so small. I can add one if you prefer to have one.