### PR TITLE
Make `Test2::Tools::Warnings` warn when called in void context, like `Test2::Tools::Exception`

### DIFF
--- a/lib/Test2/Tools/Warnings.pm
+++ b/lib/Test2/Tools/Warnings.pm
@@ -4,6 +4,7 @@ use warnings;
 
 our $VERSION = '1.302210';
 
+use Carp qw/carp/;
 use Test2::API qw/context test2_add_pending_diag/;
 
 our @EXPORT = qw/warns warning warnings no_warnings/;
@@ -11,6 +12,9 @@ use base 'Exporter';
 
 sub warns(&) {
     my $code = shift;
+
+    defined wantarray or carp "Useless use of warns() in void context";
+
     my $warnings = 0;
     local $SIG{__WARN__} = sub { $warnings++ };
     $code->();
@@ -18,6 +22,8 @@ sub warns(&) {
 }
 
 sub no_warnings(&) {
+    defined wantarray or carp "Useless use of no_warnings() in void context";
+
     my $warnings = &warnings(@_);
     return 1 if !@$warnings;
 
@@ -28,6 +34,9 @@ sub no_warnings(&) {
 
 sub warning(&) {
     my $code = shift;
+
+    defined wantarray or carp "Useless use of warning() in void context";
+
     my @warnings;
     {
         local $SIG{__WARN__} = sub { push @warnings => @_ };
@@ -47,6 +56,8 @@ sub warning(&) {
 
 sub warnings(&) {
     my $code = shift;
+
+    defined wantarray or carp "Useless use of warnings() in void context";
 
     my @warnings;
     local $SIG{__WARN__} = sub { push @warnings => @_ };

--- a/t/modules/Plugin/SRand.t
+++ b/t/modules/Plugin/SRand.t
@@ -85,16 +85,16 @@ sub intercept_2(&) {
     );
     ok($CLASS->seed && $CLASS->seed != 1234, "set seed");
     is($CLASS->from, 'local date', "set from");
-    like($warning, $reseed_qr, $reseed_name);
+    $warning = like($warning, $reseed_qr, $reseed_name);
 
     my $hooks = Test2::API::test2_list_exit_callbacks();
     delete $ENV{HARNESS_IS_VERBOSE};
     $ENV{HARNESS_ACTIVE} = 1;
-    warning { $events = intercept { $CLASS->import() } };
-    warning { $events = intercept { $CLASS->import() } };
+    $warning = warning { $events = intercept { $CLASS->import() } };
+    $warning = warning { $events = intercept { $CLASS->import() } };
     is(Test2::API::test2_list_exit_callbacks, $hooks + 1, "added hook, but only once");
 
-    warning { $CLASS->import(undef) };
+    $warning = warning { $CLASS->import(undef) };
     is($CLASS->seed, 0 , "set seed");
     is($CLASS->from, 'import arg', "set from");
 }

--- a/t/modules/Tools/ClassicCompare.t
+++ b/t/modules/Tools/ClassicCompare.t
@@ -257,7 +257,7 @@ $line = __LINE__ + 2;
 like(
     intercept {
         local $ENV{TS_TERM_SIZE} = 10000;
-        main::warning {
+        $warning = main::warning {
             cmp_ok($foo, '&& die', $foo, 'overload exception', 'extra diag')
         }
     },
@@ -312,12 +312,13 @@ note "cmp_ok() displaying good numbers"; {
 }
 
 
+my $warnings;
 note "cmp_ok() displaying bad numbers"; {
     my $have = "zero";
     my $want = "3point5";
     like(
         intercept {
-            warnings { cmp_ok($have, '>', $want) };
+            $warnings = warnings { cmp_ok($have, '>', $want) };
         },
         array {
             fail_events Ok => sub {

--- a/t/modules/Tools/Warnings.t
+++ b/t/modules/Tools/Warnings.t
@@ -55,7 +55,7 @@ is(
 my ($events, $warn);
 $events = intercept {
     $warn = warning {
-        warning { warn "a\n"; warn "b\n" };
+        scalar warning { warn "a\n"; warn "b\n" };
     };
 };
 
@@ -72,6 +72,30 @@ like(
         event Note => { message => "b\n" };
     },
     "Got warnings as notes."
+);
+
+like(
+    warning { warns { 1 } },
+    qr/Useless use of warns\(\) in void context/,
+    "warns in void context"
+);
+
+like(
+    warning { warning { 1 } },
+    qr/Useless use of warning\(\) in void context/,
+    "warns in void context"
+);
+
+like(
+    warning { warnings { 1 } },
+    qr/Useless use of warnings\(\) in void context/,
+    "warns in void context"
+);
+
+like(
+    warning { no_warnings { 1 } },
+    qr/Useless use of no_warnings\(\) in void context/,
+    "warns in void context"
 );
 
 done_testing;


### PR DESCRIPTION
This PR makes the functions of `Test2::Tools::Warnings` issue a warning when called in a void context, just like `Test2::Tools::Exception`.