### PR TITLE
Fix name typo(s) in Pod documentations

### DIFF
--- a/lib/Test2/Hub.pm
+++ b/lib/Test2/Hub.pm
@@ -713,7 +713,7 @@ process or thread. You can always add a pre_filter.
 These can be used to remove filters and pre_filters. The C<$sub> argument is
 the reference returned by C<filter()> or C<pre_filter()>.
 
-=item $hub->follow_op(sub { ... })
+=item $hub->follow_up(sub { ... })
 
 Use this to add behaviors that are called just before the hub is finalized. The
 only argument to your codeblock will be a L<Test2::EventFacet::Trace> instance.


### PR DESCRIPTION
This is yet another typo fix...

As I explained in the commit, `Test2::Hub`'s [follow_op()](https://metacpan.org/pod/Test2::Hub#$hub-%3Efollow_op(sub-{-...-})) is just one I happened to stumble upon. At the moment, this is not a comprehensive patch (hence the draft status). Once complete, this patch should ensure that method/subroutine names are spelled correctly across all PODs. Let me know if there is any interest for a thorough check for typos like this. :)

The `pod-fix` branch is based on v1.302209. I have reviewed the four open pull requests here on GitHub and did a basic search in the GitHub issues, and this does not seem to be a duplicate among any of those.