### PR TITLE
calculate CAN_SIGSYS when called rather than as a constant

### DIFF
--- a/lib/Test2/API/Instance.pm
+++ b/lib/Test2/API/Instance.pm
@@ -8,7 +8,7 @@ our @CARP_NOT = qw/Test2::API Test2::API::Instance Test2::IPC::Driver Test2::For
 use Carp qw/confess carp/;
 use Scalar::Util qw/reftype/;
 
-use Test2::Util qw/get_tid USE_THREADS CAN_FORK pkg_to_file try CAN_SIGSYS/;
+use Test2::Util qw/get_tid USE_THREADS CAN_FORK pkg_to_file try/;
 
 use Test2::EventFacet::Trace();
 use Test2::API::Stack();

--- a/lib/Test2/Util.pm
+++ b/lib/Test2/Util.pm
@@ -166,13 +166,12 @@ sub _check_for_sig_sys {
     return $sig_list =~ m/\bSYS\b/;
 }
 
-BEGIN {
-    if (_check_for_sig_sys($Config{sig_name})) {
-        *CAN_SIGSYS = sub() { 1 };
+my $CAN_SIGSYS;
+sub CAN_SIGSYS () {
+    if (!defined $CAN_SIGSYS) {
+        $CAN_SIGSYS = _check_for_sig_sys($Config{sig_name});
     }
-    else {
-        *CAN_SIGSYS = sub() { 0 };
-    }
+    $CAN_SIGSYS;
 }
 
 my %PERLIO_SKIP = (


### PR DESCRIPTION
CAN_SIGSYS is not used by Test2 anymore since the removal of the shm code in 4c1bdd27e7f7694cbdfe4ec83b79b1cf791b4bc5. It is however still used by Test2::Harness.

%Config has magic behavior where some values exist in Config.pm, and others need to load Config_heavy.pl. Checking the sig_name value will always force Config_heavy.pl to be loaded. Since CAN_SIGSYS is mostly not used, having it always force loading the heavy config provides a minor slowdown of loading Test::More. We can provide the function as a runtime check rather than a constant to avoid this.