### PR TITLE
Net::BitTorrent has been rewritten from scratch and properly uses Test2::V1

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -57,7 +57,6 @@ Unicode::LineBreak = 0
 
 [Breaks]
 Log::Dispatch::Config::TestLog = <= 0.02
-Net::BitTorrent                = <= 0.052
 Test::Able                     = <= 0.11
 Test::Aggregate                = <= 0.373
 Test::Alien                    = <= 0.04

--- a/lib/Test2/API/Breakage.pm
+++ b/lib/Test2/API/Breakage.pm
@@ -43,7 +43,6 @@ sub upgrade_required {
 
 sub known_broken {
     return (
-        'Net::BitTorrent'       => '0.052',
         'Test::Able'            => '0.11',
         'Test::Aggregate'       => '0.373',
         'Test::Flatten'         => '0.11',

--- a/lib/Test2/Transition.pod
+++ b/lib/Test2/Transition.pod
@@ -306,14 +306,6 @@ something new (Test2) to completely rewrite it in a sane way.
 
 Still broken as of version: 0.32
 
-=item Net::BitTorrent
-
-The tests for this module directly access L<Test::Builder> hash keys. Most, if
-not all of these hash keys have public API methods that could be used instead
-to avoid the problem.
-
-Still broken in version: 0.052
-
 =item Test::Group
 
 It monkeypatches Test::Builder, and calls it "black magic" in the code.

--- a/xt/downstream_dists.list.known_broken
+++ b/xt/downstream_dists.list.known_broken
@@ -6,7 +6,6 @@ Test::Kit
 Test::Group
 Test::Flatten
 Test2::Harness
-Net::BitTorrent
 Lexical::Types
 Test::Class::Moose
 Test::Mocha


### PR DESCRIPTION
Cyberbullying works. Net::BitTorrent v2.0.x is now on CPAN.