### PR TITLE
Amend tests to adapt to more accurate line number reporting in core

### DIFF
--- a/t/Legacy/subtest/line_numbers.t
+++ b/t/Legacy/subtest/line_numbers.t
@@ -13,6 +13,16 @@ BEGIN {
     }
 }
 
+# Detect the line numbering behaviour of this version of perl
+our $use_block_end;
+BEGIN {
+    sub X { my (undef, undef, $line) = caller;
+            $use_block_end++ if ($line != shift);
+    }
+    X __LINE__, # $use_block_end = 0
+    sub { }     # $use_block_end = 1
+}
+
 use strict;
 use warnings;
 
@@ -37,12 +47,13 @@ our %line;
     test_err("#   Failed test 'namehere'");
     test_err("#   at $0 line $line{outerfail1}.");
 
+    BEGIN{ $line{outerfail1} = __LINE__ + ($use_block_end ? 6 : 1) }
     subtest namehere => sub {
         plan tests => 3;
         ok 1;
         ok 0; BEGIN{ $line{innerfail1} = __LINE__ }
         ok 1;
-    }; BEGIN{ $line{outerfail1} = __LINE__ }
+    };
     
     test_test("un-named inner tests");
 }
@@ -59,23 +70,25 @@ our %line;
     test_err("#   Failed test 'namehere'");
     test_err("#   at $0 line $line{outerfail2}.");
 
+    BEGIN{ $line{outerfail2} = __LINE__ + ($use_block_end ? 6 : 1) }
     subtest namehere => sub {
         plan tests => 3;
         ok 1, "first is good";
         ok 0, "second is bad"; BEGIN{ $line{innerfail2} = __LINE__ }
         ok 1, "third is good";
-    }; BEGIN{ $line{outerfail2} = __LINE__ }
+    };
     
     test_test("named inner tests");
 }
 
 sub run_the_subtest {
+    BEGIN{ $line{outerfail3} = __LINE__ + ($use_block_end ? 6 : 1) }
     subtest namehere => sub {
         plan tests => 3;
         ok 1, "first is good";
         ok 0, "second is bad"; BEGIN{ $line{innerfail3} = __LINE__ }
         ok 1, "third is good";
-    }; BEGIN{ $line{outerfail3} = __LINE__ }
+    };
 }
 {
     test_out("# Subtest: namehere");
@@ -102,9 +115,10 @@ sub run_the_subtest {
     test_err(q{#   Failed test 'No tests run for subtest "namehere"'});
     test_err( "#   at $0 line $line{outerfail4}.");
 
+    BEGIN{ $line{outerfail4} = __LINE__ + ($use_block_end ? 3 : 1) }
     subtest namehere => sub {
         done_testing;
-    }; BEGIN{ $line{outerfail4} = __LINE__ }
+    };
 
     test_test("lineno in 'No tests run' diagnostic");
 }
@@ -121,10 +135,11 @@ sub run_the_subtest {
     test_err("#   Failed test 'namehere'");
     test_err("#   at $0 line $line{is_outer_fail}.");
 
+    BEGIN{ $line{is_outer_fail} = __LINE__  + ($use_block_end ? 4 : 1) }
     subtest namehere => sub {
         plan tests => 1;
         is 'foo', 'bar', 'foo is bar'; BEGIN{ $line{is_fail} = __LINE__ }
-    }; BEGIN{ $line{is_outer_fail} = __LINE__ }
+    };
 
     test_test("diag indent for is() in subtest");
 }

--- a/t/Legacy/subtest/predicate.t
+++ b/t/Legacy/subtest/predicate.t
@@ -13,6 +13,17 @@ BEGIN {
     }
 }
 
+
+# Detect the line numbering behaviour of this version of perl
+our $use_block_end;
+BEGIN {
+    sub X { my (undef, undef, $line) = caller;
+            $use_block_end++ if ($line != shift);
+    }
+    X __LINE__, # $use_block_end = 0
+    sub { }     # $use_block_end = 1
+}
+
 use strict;
 use warnings;
 
@@ -156,11 +167,12 @@ sub barfoo_ok_2 ($;$) {
     test_err("#   Failed test 'outergroup'");
     test_err("#   at $0 line $line{outercall}.");
 
+    BEGIN{ $line{outercall} = __LINE__ + ( $use_block_end ? 5 : 1 ) }
     subtest outergroup => sub {
         plan tests => 2;
         ok 1, "this passes";
         barfoo_ok_2 "foot", "namehere"; BEGIN{ $line{ipredcall} = __LINE__ }
-    }; BEGIN{ $line{outercall} = __LINE__ }
+    };
 
     test_test("outergroup with internal barfoo_ok_2 failing line numbers");
 }

--- a/t/modules/Tools/Subtest.t
+++ b/t/modules/Tools/Subtest.t
@@ -5,6 +5,16 @@ use Test2::Tools::Subtest qw/subtest_streamed subtest_buffered/;
 
 use File::Temp qw/tempfile/;
 
+# Detect the line numbering behaviour of this version of perl
+our $use_block_end;
+BEGIN {
+    sub X { my (undef, undef, $line) = caller;
+            $use_block_end++ if ($line != shift);
+    }
+    X __LINE__, # $use_block_end = 0
+    sub { }     # $use_block_end = 1
+}
+
 # A bug in older perls causes a strange error AFTER the program appears to be
 # done if this test is run.
 # "Size magic not implemented."
@@ -83,7 +93,7 @@ like(
 my @lines = ();
 like(
     intercept {
-        push @lines => __LINE__ + 4;
+        push @lines => __LINE__ + ( $use_block_end ? 4 : 1 );
         subtest_streamed 'foo' => sub {
             push @lines => __LINE__ + 1;
             ok(1, "pass");
@@ -112,7 +122,7 @@ like(
 @lines = ();
 like(
     intercept {
-        push @lines => __LINE__ + 4;
+        push @lines => __LINE__ + ( $use_block_end ? 4 : 1 );
         subtest_streamed 'foo' => sub {
             push @lines => __LINE__ + 1;
             ok(0, "fail");
@@ -141,7 +151,7 @@ like(
 @lines = ();
 like(
     intercept {
-        push @lines => __LINE__ + 5;
+        push @lines => __LINE__ + ( $use_block_end ? 5 : 1 );
         subtest_streamed 'foo' => sub {
             push @lines => __LINE__ + 1;
             ok(1, "pass");
@@ -329,7 +339,7 @@ like(
 @lines = ();
 like(
     intercept {
-        push @lines => __LINE__ + 5;
+        push @lines => __LINE__ + ( $use_block_end ? 5 : 1 );
         subtest_buffered 'foo' => sub {
             plan 1;
             push @lines => __LINE__ + 1;
@@ -359,7 +369,7 @@ like(
 @lines = ();
 like(
     intercept {
-        push @lines => __LINE__ + 5;
+        push @lines => __LINE__ + ( $use_block_end ? 5 : 1 );
         subtest_buffered 'foo' => sub {
             skip_all 'bleh';
             push @lines => __LINE__ + 1;

--- a/t/regression/684-nested_todo_diag.t
+++ b/t/regression/684-nested_todo_diag.t
@@ -2,6 +2,16 @@ use Test::More;
 use strict;
 use warnings;
 
+# Detect the line numbering behaviour of this version of perl
+our $use_block_end;
+BEGIN {
+    sub X { my (undef, undef, $line) = caller;
+            $use_block_end++ if ($line != shift);
+    }
+    X __LINE__, # $use_block_end = 0
+    sub { }     # $use_block_end = 1
+}
+
 use Test2::API qw/intercept/;
 my @events;
 
@@ -17,7 +27,9 @@ intercept {
     };
 };
 
-my ($event) = grep { $_->trace->line == 16 && ref($_) eq 'Test::Builder::TodoDiag'} @events;
-ok($event, "nested todo diag on line 16 was changed to TodoDiag (STDOUT instead of STDERR)");
+my $target_line = ($use_block_end) ? 26 : 23;
+
+my ($event) = grep { $_->trace->line == $target_line && ref($_) eq 'Test::Builder::TodoDiag'} @events;
+ok($event, "nested todo diag on line $target_line was changed to TodoDiag (STDOUT instead of STDERR)");
 
 done_testing;


### PR DESCRIPTION
Early in the next development cycle of the perl interpreter, an attempt will be made to improve the inaccuracy of line number reporting by warnings/error and caller(), starting with:

- https://github.com/Perl/perl5/pull/24387 - starting statement in elsif() blocks
- https://github.com/Perl/perl5/pull/24389 - loop condition statements 
- https://github.com/Perl/perl5/pull/24396 - mid-statement anon sub declarations

These changes break assorted tests in this module that expect specific line numbers to be emitted.

This commit should ensure that the affected tests succeed regardless of whether the perl version in use demonstrates the older, buggier behaviour or the behaviour once the above pull requests are merged. (This would also reduce churn if those PRs are merged and present in some tagged releases, but then later reverted.)