### PR TITLE
Simplify Test::Builder->skip monkeypatching to accept test reason

### DIFF
--- a/lib/Test/Builder.pm
+++ b/lib/Test/Builder.pm
@@ -1068,6 +1068,18 @@ sub BAIL_OUT {
     *BAILOUT = \&BAIL_OUT;
 }
 
+sub _tctx_skip {
+	my ($self, $tctx, $name, $why) = @_;
+
+    $tctx->skip ('', $why);
+}
+
+sub _tctx_skip_with_name {
+	my ($self, $tctx, $name, $why) = @_;
+
+    $tctx->skip ($name, $why);
+}
+
 sub skip {
     my( $self, $why, $name ) = @_;
     $why ||= '';
@@ -1092,7 +1104,8 @@ sub skip {
     } unless $self->{no_log_results};
 
     my $tctx = $ctx->snapshot;
-    $tctx->skip('', $why);
+
+    $self->_tctx_skip ($tctx, $name, $why);
 
     return release $ctx, 1;
 }

--- a/t/Legacy/Builder/details.t
+++ b/t/Legacy/Builder/details.t
@@ -15,7 +15,7 @@ use Test::More;
 use Test::Builder;
 my $Test = Test::Builder->new;
 
-$Test->plan( tests => 9 );
+$Test->plan( tests => 11 );
 $Test->level(0);
 
 my @Expected_Details;
@@ -93,6 +93,35 @@ $Test->is_num( scalar @details, 6,
 $Test->level(1);
 is_deeply( \@details, \@Expected_Details );
 
+{
+	SKIP: {
+		$Test->skip( 'by default skip ignores reason', 'test message' );
+	}
+
+	push @Expected_Details, {
+		ok        => 1,
+		actual_ok => 1,
+		name      => 'test message',
+		type      => 'skip',
+		reason    => '',
+	};
+}
+
+{
+	SKIP: {
+		no warnings q (redefine);
+		local *Test::Builder::_tctx_skip = \ &Test::Builder::_tctx_skip_with_name;
+		$Test->skip( 'monkeypatching skip to use provided reason', 'test message' );
+	}
+
+	push @Expected_Details, {
+		ok        => 1,
+		actual_ok => 1,
+		name      => 'test message',
+		type      => 'skip',
+		reason    => 'monkeypatching skip to use provided reason',
+	};
+}
 
 # This test has to come last because it thrashes the test details.
 {
@@ -103,3 +132,4 @@ is_deeply( \@details, \@Expected_Details );
     $Test->current_test($curr_test);
     $Test->is_num( scalar @details, 4 );
 }
+


### PR DESCRIPTION
The test reason is already recognized and accepted by the context, but for some reason it is not used.

To allow users of T:B to use provided reason, usage (or in fact not-usage) of test reason is extracted into method `_tctx_skip`.